### PR TITLE
Bump version 0.4.0 → 0.5.0

### DIFF
--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-	  <Version>0.4.0</Version>
+	  <Version>0.5.0</Version>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>Contains class for generating random numbers by simulating rolling of dice with various number of sides</Description>

--- a/tests/Wolfgang.D20.Dice.Tests/Wolfgang.D20.Dice.Tests.Unit.csproj
+++ b/tests/Wolfgang.D20.Dice.Tests/Wolfgang.D20.Dice.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net47;net471;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-	<Version>0.4.0</Version>
+	<Version>0.5.0</Version>
 	<LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
Bumps `Wolfgang.D20.Dice` package version 0.4.0 → 0.5.0 to release accumulated changes since the v0.4.0 tag:

- **Roll() correctness fixes** — off-by-one, `Random` allocation, overflow safety, stale docs.
- **Copilot review feedback** — overflow safety, additional tests, docfx docs.
- Analyzer PackageReferences centralized via `Directory.Build.props`.
- Canonical drift sync (.editorconfig, workflows, ruleset alignment).
- 3 grouped dependency bumps from Dependabot.

## Test plan
- [ ] CI green
- [ ] Tag v0.5.0 + GitHub Release after merge → release.yaml publishes to NuGet

🤖 Generated with [Claude Code](https://claude.com/claude-code)