### PR TITLE
pr.yaml: trust Dependabot in Protected File Check guard

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -94,7 +94,15 @@ jobs:
   check-protected-files:
     name: "Protected File Check"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
+    # Skip for Dependabot — its package-version bumps to protected files
+    # (e.g. Directory.Build.props analyzer references) are legitimate and
+    # the threat model of this guard is human PR authors disabling
+    # analyzers in their own PRs, not GitHub-controlled package bots.
+    # Required status checks treat skipped jobs as passing, so this lets
+    # Dependabot PRs auto-merge without a maintainer override.
+    if: |
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
The `check-protected-files` job (status name **Protected File Check**) unconditionally fails on any change to protected config files, with no exemption for Dependabot. That blocks every Dependabot PR that bumps an analyzer version (since analyzer `PackageReference` lives in `Directory.Build.props`), forcing a maintainer override to merge what should be a hands-off auto-merge.

## Fix
Adds the standard Dependabot guard to the job-level `if:`:

```yaml
if: |
  github.repository != 'Chris-Wolfgang/repo-template' &&
  github.event.pull_request.user.login != 'dependabot[bot]'
```

Required status checks treat skipped jobs as passing, so once this lands, Dependabot PRs whose only protected-file change is an analyzer-version bump will turn green on this check.

## Why this is safe
- The threat model is human PR authors disabling analyzers in their own PRs. Dependabot is GitHub-controlled and not spoofable; its only action is package-version updates.
- The branch-ruleset still requires the check; Dependabot's "skipped" simply counts as pass.

## Note on pattern consistency
This `pr.yaml` variant centralizes all protected-file guarding in the standalone `check-protected-files` job — there are no inline per-job guards to align with here (newer template revisions in other repos do have inline guards, each carrying the same Dependabot exemption; this PR brings the centralized-guard variant up to the same effective behavior).

## Test plan
- [ ] After merge, re-run the Protected File Check on PR #100 and confirm it turns green
- [ ] Non-Dependabot PRs continue to be blocked when they touch protected files