### PR TITLE
P3: add canonical benchmarks/.editorconfig (closes #134)

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -9,13 +9,16 @@
 #
 # This file is the canonical home for benchmark-inappropriate
 # analyzer suppressions. As BDN-typical warnings surface during
-# benchmark expansion, add per-rule severity overrides here rather
-# than blanket-disabling TWEA on the folder.
-#
-# Examples (commented out — none required yet for this repo):
-#   dotnet_diagnostic.CA1822.severity = none      # methods don't access this
-#   dotnet_diagnostic.MA0048.severity = none      # File name does not match
-#   dotnet_diagnostic.S1144.severity  = none      # Unused private members (reflection)
-#   dotnet_diagnostic.S2933.severity  = none      # Fields used by reflection should be private
+# benchmark expansion, add per-rule severity overrides BELOW the
+# `[*.cs]` section header rather than blanket-disabling TWEA on
+# the folder. Properties placed before any section header are
+# ignored by most EditorConfig parsers — keep entries inside
+# `[*.cs]`.
 
 [*.cs]
+
+# Examples (commented out — none required yet for this repo):
+# dotnet_diagnostic.CA1822.severity = none      # methods don't access this
+# dotnet_diagnostic.MA0048.severity = none      # File name does not match
+# dotnet_diagnostic.S1144.severity  = none      # Unused private members (reflection)
+# dotnet_diagnostic.S2933.severity  = none      # Fields used by reflection should be private

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,21 @@
+# Benchmark-project analyzer carve-outs (canonical).
+#
+# Benchmark projects inherit `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
+# from the root `Directory.Build.props` in Release builds — same bar as
+# src/ and tests/. BenchmarkDotNet code patterns (deliberately naive
+# measured code, `[Benchmark]` methods invoked by reflection, fields
+# mutated by harness, etc.) can trip some analyzer rules that would
+# otherwise be reasonable.
+#
+# This file is the canonical home for benchmark-inappropriate
+# analyzer suppressions. As BDN-typical warnings surface during
+# benchmark expansion, add per-rule severity overrides here rather
+# than blanket-disabling TWEA on the folder.
+#
+# Examples (commented out — none required yet for this repo):
+#   dotnet_diagnostic.CA1822.severity = none      # methods don't access this
+#   dotnet_diagnostic.MA0048.severity = none      # File name does not match
+#   dotnet_diagnostic.S1144.severity  = none      # Unused private members (reflection)
+#   dotnet_diagnostic.S2933.severity  = none      # Fields used by reflection should be private
+
+[*.cs]


### PR DESCRIPTION
## Summary

#134 acceptance criteria are largely already satisfied for D20-Dice — this PR adds the one missing artifact.

| Acceptance | Status |
|---|---|
| `benchmarks/Directory.Build.props` removed | ✅ never existed in D20-Dice — no TWEA=false override to drop |
| Benchmark project builds clean in Release with TWEA | ✅ verified locally (0 warnings, 0 errors) |
| Curated `benchmarks/.editorconfig` exists | ➕ added by this PR |

The benchmarks already inherit `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` from the root `Directory.Build.props` and currently build clean — no BDN patterns trip analyzers in this small `DiceBenchmarks` suite today.

## What this PR adds

`benchmarks/.editorconfig` is the canonical landing spot for BDN-inappropriate rule suppressions. Header documents the purpose; example rules (CA1822 / MA0048 / S1144 / S2933) sit commented-out so they're ready to enable if/when the BDN suite grows and trips them.

Pattern parallels `tests/.editorconfig` (which already carries the test-specific suppressions on canonical-protected).

Stacked on top of vNext (PR #144).