### PR TITLE
Protected canonical files for v0.5.1 (admin-bypass split)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,13 +25,12 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
-[*.ps1]
-indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
+# PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no per-language override is needed.
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang (where
+# present) on scripts under scripts/ to work on Linux/macOS — CR
+# breaks the kernel's exec lookup, and a leading BOM prevents shebang
+# recognition entirely.
 
 # C# files
 [*.cs]

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,88 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.D20.Dice.Benchmarks/Wolfgang.D20.Dice.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.D20.Dice.Benchmarks/Wolfgang.D20.Dice.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.D20.Dice.Benchmarks
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.D20.Dice.Benchmarks
+        run: |
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.D20.Dice.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -12,6 +12,9 @@ name: Build All Versioned Docs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read  # Default to read-only; the build-and-deploy job overrides with write
+
 jobs:
   build-and-deploy:
     name: Build & Deploy All Versioned Docs
@@ -25,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history so all tags are reachable
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -38,7 +42,8 @@ jobs:
             10.0.x
 
       - name: Install DocFX
-        run: dotnet tool update docfx --global
+        run: |
+          dotnet tool update docfx --global || dotnet tool install docfx --global
         shell: pwsh
 
       - name: Build docs for each version
@@ -114,20 +119,20 @@ jobs:
             try {
               # Attempt dotnet restore + build; failures are non-fatal because
               # DocFX can still extract metadata from source files.
-              $slnFile = Get-ChildItem -Filter '*.sln' -ErrorAction SilentlyContinue |
+              $slnFile = Get-ChildItem -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -in '.sln','.slnx' } |
                          Select-Object -First 1
               if ($slnFile) {
                 Write-Host "Restoring $($slnFile.Name)..."
-                dotnet restore $slnFile.FullName 2>&1 | Write-Host
+                dotnet restore $slnFile.FullName 2>&1 | Out-Host
                 Write-Host "Building $($slnFile.Name)..."
-                dotnet build $slnFile.FullName --configuration Release --no-restore 2>&1 | Write-Host
+                dotnet build $slnFile.FullName --configuration Release --no-restore 2>&1 | Out-Host
               }
 
               Write-Host "Running docfx metadata..."
-              docfx metadata docfx_project/docfx.json 2>&1 | Write-Host
+              docfx metadata docfx_project/docfx.json 2>&1 | Out-Host
 
               Write-Host "Running docfx build..."
-              docfx build docfx_project/docfx.json 2>&1 | Write-Host
+              docfx build docfx_project/docfx.json 2>&1 | Out-Host
 
               if (Test-Path 'docfx_project/_site') {
                 $dest = Join-Path $outDir 'versions' $version
@@ -202,7 +207,7 @@ jobs:
 
           Push-Location $latestWorkDir
           try {
-            $slnFile = Get-ChildItem -Filter '*.sln' -ErrorAction SilentlyContinue |
+            $slnFile = Get-ChildItem -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -in '.sln','.slnx' } |
                        Select-Object -First 1
             if ($slnFile) {
               Write-Host "Restoring $($slnFile.Name)..."
@@ -280,9 +285,22 @@ jobs:
             Sort-Object -Property Major, Minor, Patch, Stable -Descending |
             Select-Object -ExpandProperty Tag
 
+          # Only emit version-picker entries for tags whose docs were actually
+          # built and copied under $outDir/versions/<tag>/. Skipped tags (worktree
+          # add failed, DocFX produced no _site, etc.) would otherwise appear in
+          # versions.json as links to 404s on gh-pages.
+          $versionsDir = Join-Path $outDir 'versions'
+          $builtTags = if (Test-Path $versionsDir) {
+            Get-ChildItem -Path $versionsDir -Directory | Select-Object -ExpandProperty Name
+          } else { @() }
+
           [array]$versions = @([PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" })
           foreach ($t in $orderedTags) {
-            $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
+            if ($builtTags -contains $t) {
+              $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
+            } else {
+              Write-Host "::notice::Skipping versions.json entry for $t — no built docs under versions/$t/"
+            }
           }
 
           $versionsJson = ConvertTo-Json -InputObject $versions -Depth 3
@@ -318,12 +336,11 @@ jobs:
           $listHtml = $listItems -join "`n"
 
           $templatePath = '.github/version-picker-template.html'
-          if (Test-Path $templatePath) {
-            $template = Get-Content $templatePath -Raw
-          } else {
-            Write-Host "Template file '$templatePath' not found. Using built-in fallback template."
+          if (-not (Test-Path $templatePath)) {
+            Write-Error "Template file '$templatePath' not found. This file is required."
             exit 1
           }
+          $template = Get-Content $templatePath -Raw
           $html = $template -replace '\{\{TITLE\}\}', $title `
                             -replace '\{\{VERSION_LIST\}\}', $listHtml
 
@@ -334,7 +351,7 @@ jobs:
         # Publishes the entire all_version_docs/ output directory to gh-pages
         # at the site root.  keep_files: true preserves any other content
         # already present on the branch (CNAME, root assets, etc.).
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ runner.temp }}/all_version_docs

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read  # Default to read-only; the analyze job overrides where required
+
 jobs:
   analyze:
     name: "Security Scan (CodeQL)"
@@ -25,6 +32,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Check for C# source code
       id: check-csharp
@@ -71,12 +80,43 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        # security-extended adds the broader security query pack on top of the
+        # default queries (more rules, slightly longer scans).
+        queries: security-extended
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
+
+    - name: Restore .NET workloads
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      shell: pwsh
+      run: |
+        # Skip entirely if no csproj declares a workload-bearing TFM (android/ios/
+        # maccatalyst/maui/tvos/tizen/browser) — netX.Y-windows TFMs use
+        # SDK-bundled projection assemblies, not the workload installer, so
+        # they're intentionally excluded. Saves ~5-15s on pure-library
+        # repos and removes a network-dependent failure mode.
+        $hasWorkloadTfm = @(Get-ChildItem -Recurse -Filter *.csproj |
+                           Select-String -Pattern 'net\d+\.\d+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' -List).Count -gt 0
+        if (-not $hasWorkloadTfm) {
+          Write-Host "No workload-bearing TFMs — skipping dotnet workload restore"
+          exit 0
+        }
+        $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+        if ($solution) {
+          Write-Host "Restoring workloads for $($solution.FullName)"
+          dotnet workload restore "$($solution.FullName)"
+        } else {
+          Write-Host "No solution found; restoring workloads for all projects"
+          dotnet workload restore
+        }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "dotnet workload restore failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
 
     - name: Build for CodeQL Analysis
       id: build

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -38,6 +38,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read  # Default to read-only; the build-and-deploy job overrides with write
+
 jobs:
   build-and-deploy:
     name: Build & Deploy Documentation
@@ -51,6 +54,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -72,7 +76,7 @@ jobs:
         shell: pwsh
 
       - name: Install DocFX
-        run: dotnet tool update docfx --global
+        run: dotnet tool update docfx --global || dotnet tool install docfx --global
         shell: pwsh
 
       - name: Build DocFX Metadata
@@ -97,10 +101,39 @@ jobs:
           Get-ChildItem "docfx_project/_site/api"
         shell: pwsh
 
+      - name: Generate code-coverage report into docs site (T1)
+        # Initiative T1 — publish coverage report to gh-pages alongside docs.
+        # Runs the test suite with Cobertura coverage collection, then uses
+        # ReportGenerator to render an HTML report into _site/coverage/.
+        # The published docs site gains a /coverage/ subpath.
+        # continue-on-error means a coverage failure (no tests, flaky tests,
+        # report generation issues) does not block the docs deploy.
+        if: hashFiles('tests/**/*.csproj') != ''
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          # Coverage report only needs one TFM's worth of runs. The per-PR
+          # pr.yaml workflow already exercises every TFM across Stages 1/2/3,
+          # so re-running the full matrix during docs deploy multiplies job
+          # time and adds extra failure surface for older targets. Pin to
+          # net10.0 — the modern target that's always present in this fleet.
+          dotnet test --configuration Release --no-build --no-restore --framework net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./coverage-raw 2>&1 | Out-Host
+          dotnet tool update -g dotnet-reportgenerator-globaltool 2>$null || dotnet tool install -g dotnet-reportgenerator-globaltool 2>$null
+          $coverageFiles = @(Get-ChildItem -Path ./coverage-raw -Recurse -Filter "coverage.cobertura.xml" -ErrorAction SilentlyContinue)
+          if ($coverageFiles.Count -eq 0) {
+            Write-Host "::notice::No coverage files generated - skipping coverage report step"
+            exit 0
+          }
+          $reports = ($coverageFiles | ForEach-Object { $_.FullName }) -join ';'
+          $outDir = "docfx_project/_site/coverage"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          reportgenerator "-reports:$reports" "-targetdir:$outDir" "-reporttypes:Html;TextSummary"
+          Write-Host "Coverage report written to $outDir"
+
       - name: Generate versions.json
         # Produces versions.json consumed by the DocFX version-switcher dropdown.
         # Site layout:
-        #   /<repo>/               ← latest docs (deployed to root)
+        #   /<repo>/               ← version-picker index.html (deployed to root)
         #   /<repo>/versions/latest/  ← latest docs (alias under versions/)
         #   /<repo>/versions/v1.2.3/  ← versioned docs (under versions/)
         # versions.json format expected by the dropdown:
@@ -122,19 +155,92 @@ jobs:
               # Sorting descending by Stable places stable (1) before prerelease (0) of the same version.
               $stable = if ([string]::IsNullOrEmpty($Matches['prerelease'])) { 1 } else { 0 }
               [PSCustomObject]@{
-                Tag    = $t
-                Major  = [int]$Matches['major']
-                Minor  = [int]$Matches['minor']
-                Patch  = [int]$Matches['patch']
-                Stable = $stable
+                Tag        = $t
+                Major      = [int]$Matches['major']
+                Minor      = [int]$Matches['minor']
+                Patch      = [int]$Matches['patch']
+                Stable     = $stable
+                PreRelease = $Matches['prerelease']
               }
             }
           }
 
-          # Sort descending by SemVer components so newest stable version comes first
-          $orderedTags = $taggedVersions |
-            Sort-Object -Property Major, Minor, Patch, Stable -Descending |
-            Select-Object -ExpandProperty Tag
+          # Sort descending by full SemVer precedence (Major, Minor, Patch, Stable, PreRelease)
+          # Convert to a mutable list so we can use a custom comparison for proper SemVer prerelease ordering.
+          $tagList = [System.Collections.Generic.List[object]]::new()
+          foreach ($item in $taggedVersions) {
+            [void]$tagList.Add($item)
+          }
+
+          $comparison = [System.Comparison[object]]{
+            param($a, $b)
+
+            # Compare Major, Minor, Patch (descending)
+            if ($a.Major -ne $b.Major) { return [Math]::Sign($b.Major - $a.Major) }
+            if ($a.Minor -ne $b.Minor) { return [Math]::Sign($b.Minor - $a.Minor) }
+            if ($a.Patch -ne $b.Patch) { return [Math]::Sign($b.Patch - $a.Patch) }
+
+            # Compare Stable flag (descending: stable=1 > prerelease=0)
+            if ($a.Stable -ne $b.Stable) { return [Math]::Sign($b.Stable - $a.Stable) }
+
+            # At this point, Major/Minor/Patch/Stable are equal.
+            # If both are stable (no prerelease), they are equal for our purposes.
+            $aPre = [string]$a.PreRelease
+            $bPre = [string]$b.PreRelease
+
+            if ([string]::IsNullOrEmpty($aPre) -and [string]::IsNullOrEmpty($bPre)) { return 0 }
+
+            # Both should be prereleases when Stable is 0, but handle any unexpected cases gracefully.
+            if ([string]::IsNullOrEmpty($aPre) -and -not [string]::IsNullOrEmpty($bPre)) { return -1 }
+            if (-not [string]::IsNullOrEmpty($aPre) -and [string]::IsNullOrEmpty($bPre)) { return 1 }
+
+            $aIds = $aPre -split '\.'
+            $bIds = $bPre -split '\.'
+            $maxLen = [Math]::Max($aIds.Length, $bIds.Length)
+
+            for ($i = 0; $i -lt $maxLen; $i++) {
+              # SemVer §11.4.4: fewer prerelease identifiers = lower precedence.
+              # In *descending* order (newest first), the lower-precedence
+              # value sorts AFTER the higher-precedence one, so the comparator
+              # must return positive when 'a' is the shorter (lower-precedence)
+              # one and negative when 'b' is.
+              if ($i -ge $aIds.Length) { return 1 }  # a has fewer identifiers -> lower precedence -> sorts later
+              if ($i -ge $bIds.Length) { return -1 } # b has fewer identifiers -> lower precedence -> sorts later
+
+              $aId = $aIds[$i]
+              $bId = $bIds[$i]
+
+              # TryParse needs [ref] to a real variable, not an expression.
+              # We don't use the out value (we re-parse below via [int]$aId).
+              $aOut = 0; $bOut = 0
+              $aIsNum = [int]::TryParse($aId, [ref]$aOut)
+              $bIsNum = [int]::TryParse($bId, [ref]$bOut)
+
+              if ($aIsNum -and $bIsNum) {
+                $aVal = [int]$aId
+                $bVal = [int]$bId
+                if ($aVal -ne $bVal) { return [Math]::Sign($bVal - $aVal) }
+              }
+              elseif ($aIsNum -and -not $bIsNum) {
+                # Numeric identifiers have lower precedence than non-numeric.
+                return 1
+              }
+              elseif (-not $aIsNum -and $bIsNum) {
+                return -1
+              }
+              else {
+                $cmp = [string]::CompareOrdinal($aId, $bId)
+                if ($cmp -ne 0) { return -$cmp }
+              }
+            }
+
+            # All identifiers equal
+            return 0
+          }
+
+          $tagList.Sort($comparison)
+          # We implemented comparison for descending SemVer order directly in the comparison.
+          $orderedTags = $tagList | Select-Object -ExpandProperty Tag
 
           # Build the base path for this GitHub Pages project site: /<repo-name>/
           # GITHUB_REPOSITORY is "owner/repo"; we need just the repo name.
@@ -151,65 +257,72 @@ jobs:
             Set-Content -Path 'docfx_project/_site/versions.json' -Encoding utf8NoBOM
           Write-Host "Generated versions.json with $($versions.Count) version(s): $($versions | ForEach-Object { $_.version })"
 
-      - name: Clean up stale root files from gh-pages
-        # Before deploying the latest docs to the site root, remove any pre-existing
-        # root-level files and folders from the gh-pages branch (except the versions/
-        # directory, CNAME, and .nojekyll) so that stale DocFX assets from a previous
-        # build do not linger on the live site.
-        # The versions/ folder is preserved so that all versioned docs remain accessible
-        # while the root is refreshed with the new build.
+      - name: Verify previous versions preserved in versions.json
+        # Initiative D6 — guard against accidentally wiping the version selector.
+        # Fetches the currently-deployed versions.json from the published
+        # GitHub Pages URL (https://<owner>.github.io/<repo>/versions.json) and confirms
+        # the newly-generated one has at least as many entries AND retains every
+        # previously-published version label. If anything shrunk or went missing,
+        # abort the deploy so the version selector cannot be wiped by accident.
+        # Only runs when an actual root-touching deploy is happening:
+        # - inputs.deploy_to_pages != false (otherwise it's a dry-run and
+        #   nothing deploys at all)
+        # - inputs.deploy_as_latest != false (otherwise the deploy writes
+        #   only versions/<dir>/ and never touches the root versions.json,
+        #   so there's nothing for the preservation guard to protect — a
+        #   transient Pages-fetch failure would block a legitimate rebuild)
         if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
         run: |
-          $branchExists = git ls-remote --heads origin gh-pages
-          if (-not $branchExists) {
-            Write-Host "ℹ️ gh-pages branch does not exist yet – skipping stale-file cleanup."
-            exit 0
+          $newPath = 'docfx_project/_site/versions.json'
+          if (-Not (Test-Path $newPath)) {
+            # This step only runs when deploy_to_pages != false, so a real
+            # deploy is about to happen. Missing newly-generated versions.json
+            # means the docfx generate step is broken — we can't verify that
+            # we're preserving previously-published versions. Failing here is
+            # safer than letting the deploy proceed and wipe the root with
+            # whatever (possibly empty) state.
+            Write-Host "::error::Newly-generated docfx_project/_site/versions.json is missing — docfx generation is broken. Refusing to deploy without a verified version manifest."
+            exit 1
           }
-
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git remote set-url origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
-
-          git fetch origin gh-pages
-          # Create a local tracking branch only if it does not already exist
-          git show-ref --verify --quiet refs/heads/gh-pages
-          if ($LASTEXITCODE -ne 0) {
-            git branch gh-pages origin/gh-pages
+          $existingUrl = "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/versions.json"
+          try {
+            $existingRaw = (Invoke-WebRequest -Uri $existingUrl -ErrorAction Stop).Content
+          } catch {
+            # Only treat a true 404 as "first deploy". Other errors (network,
+            # DNS, Pages outage, auth/redirect) must NOT silently bypass the
+            # preservation check — they could let a deploy that drops version
+            # entries from the picker slip through.
+            $status = $null
+            if ($_.Exception.Response) { $status = [int]$_.Exception.Response.StatusCode }
+            if ($status -eq 404) {
+              Write-Host "::notice::No existing versions.json at $existingUrl (404) - first deploy, skipping preservation check."
+              exit 0
+            }
+            Write-Error "Failed to fetch existing versions.json from $existingUrl (status=$status): $($_.Exception.Message). Aborting deploy to avoid masking a transient error."
+            exit 1
           }
-
-          $WORK_DIR = Join-Path $env:RUNNER_TEMP 'gh-pages-clean'
-          # Remove a leftover worktree from a previous failed run, if any
-          git worktree remove "$WORK_DIR" --force 2>&1 | Out-Null
-          if (Test-Path $WORK_DIR) { Remove-Item $WORK_DIR -Recurse -Force }
-          git worktree add "$WORK_DIR" gh-pages
-
-          # Remove all root-level items EXCEPT:
-          #   .git         – Git metadata (worktree pointer file)
-          #   CNAME        – Custom domain config (if present)
-          #   .nojekyll    – Tells GitHub Pages not to run Jekyll
-          #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
-          Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -ne '.git' -and
-            $_.Name -ne 'CNAME' -and
-            $_.Name -ne '.nojekyll' -and
-            $_.Name -ne 'versions'
-          } | Remove-Item -Recurse -Force
-
-          git -C "$WORK_DIR" add -A
-          git -C "$WORK_DIR" diff --cached --quiet
-          if ($LASTEXITCODE -ne 0) {
-            git -C "$WORK_DIR" commit `
-              -m "chore: clean up stale root DocFX assets before redeploy [skip ci]"
-            git -C "$WORK_DIR" push origin HEAD:gh-pages
-            Write-Host "✅ Stale root files removed from gh-pages."
-          } else {
-            Write-Host "ℹ️ No stale files found in gh-pages root – nothing to clean."
+          try {
+            $existing = $existingRaw | ConvertFrom-Json
+            $new = Get-Content $newPath -Raw | ConvertFrom-Json
+          } catch {
+            Write-Error "Failed to parse versions.json: $($_.Exception.Message)"
+            exit 1
           }
-
-          git worktree remove "$WORK_DIR" --force
+          $existingCount = @($existing).Count
+          $newCount = @($new).Count
+          if ($newCount -lt $existingCount) {
+            Write-Error "versions.json would lose entries: existing=$existingCount, new=$newCount. Aborting deploy."
+            exit 1
+          }
+          $existingVersions = @($existing) | ForEach-Object { $_.version }
+          $newVersions = @($new) | ForEach-Object { $_.version }
+          $missing = @($existingVersions | Where-Object { $_ -notin $newVersions })
+          if ($missing.Count -gt 0) {
+            Write-Error "Previous versions missing from new versions.json: $($missing -join ', '). Aborting deploy."
+            exit 1
+          }
+          Write-Host "versions.json preservation OK: existing=$existingCount, new=$newCount."
 
       - name: Compute destination directory
         # Determines the versioned subfolder name for the docs deployment (e.g. /v1.2.3/).
@@ -237,76 +350,208 @@ jobs:
           }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "dir=$sanitized"
 
-      - name: Deploy versioned docs to GitHub Pages
-        # Publishes this build into versions/<version>/ on gh-pages, e.g. versions/v1.2.3/.
-        # keep_files: true preserves all other version folders already present in gh-pages.
+      - name: Deploy docs to GitHub Pages
+        # Assembles the full gh-pages state and pushes a single commit, avoiding the
+        # multiple sequential pushes that would trigger pages-build-deployment repeatedly.
+        #
+        # Layout written to gh-pages in one commit:
+        #   versions/<version>/   – versioned docs (real DocFX index.html)
+        #   versions/latest/      – latest alias   (real DocFX index.html) [deploy_as_latest only]
+        #   /                     – version-picker index.html + shared assets [deploy_as_latest only]
+        #
+        # Stale root files from the previous build are removed before copying new content,
+        # so outdated DocFX assets do not linger.  The versions/ folder is always preserved
+        # so that all prior versioned docs remain accessible.
         if: inputs.deploy_to_pages != false
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docfx_project/_site
-          destination_dir: versions/${{ steps.dest.outputs.dir }}
-          keep_files: true
-          force_orphan: false
-
-      - name: Deploy latest docs to versions/latest/ folder
-        # Also publishes to versions/latest/ as a stable, bookmarkable URL alias for the
-        # latest version.  The versions.json 'latest' entry points to versions/latest/.
-        # Skipped when deploy_as_latest is false (e.g. when rebuilding an older version).
-        if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docfx_project/_site
-          destination_dir: versions/latest
-          keep_files: true
-          force_orphan: false
-
-      - name: Generate root index.html
-        # Generates the version-picker page and writes it into _site/index.html AFTER
-        # the versioned-docs deploys have already run, so versions/<tag>/ and
-        # versions/latest/ each keep the real DocFX landing page.  Only the subsequent
-        # root deploy (below) receives the picker as its index.html.
-        # Falls back to a minimal built-in template when the shared template file is not
-        # present in the checked-out commit (e.g. retroactive builds of older tags).
-        if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          VERSION_DIR: ${{ steps.dest.outputs.dir }}
+          DEPLOY_AS_LATEST: ${{ inputs.deploy_as_latest != false }}
         shell: pwsh
         run: |
-          $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
-          $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
-          $versions = Get-Content 'docfx_project/_site/versions.json' -Raw | ConvertFrom-Json
+          $WORK_DIR = Join-Path $env:RUNNER_TEMP 'gh-pages-deploy'
+          # Default to $false so the finally block uses the safe (Remove-Item)
+          # cleanup if the try block fails before $useWorktree is assigned.
+          $useWorktree = $false
+          $deployExitCode = 0
 
-          $listItems = foreach ($v in $versions) {
-            $liClass = if ($v.version -eq 'latest') { ' class="latest"' } else { '' }
-            $label   = if ($v.version -eq 'latest') { 'latest (stable)' } else { $v.version }
-            "      <li${liClass}><a href=`"$($v.url)`">$label</a></li>"
+          try {
+            # Authenticate via http.extraheader rather than embedding the token in
+            # the remote URL. This keeps the token out of `git remote -v` and
+            # error-message output, and avoids writing it into per-repo .git/config.
+            # The finally block ALWAYS unsets this so an early `exit` (e.g. failed
+            # ls-remote, missing template) cannot leave the token in the runner's
+            # global git config for subsequent steps.
+            $basicAuth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$($env:GITHUB_TOKEN)"))
+            git config --global http."https://github.com/".extraheader "AUTHORIZATION: basic $basicAuth"
+            git remote set-url origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
+
+            $siteDir = Resolve-Path 'docfx_project/_site'
+
+            # Set up gh-pages worktree (or start fresh if the branch does not exist yet).
+            # ls-remote can succeed-with-empty-output (branch missing) or fail
+            # (auth/network). Distinguish the two via $LASTEXITCODE so a transient
+            # failure does not silently route into the bootstrap path and clobber
+            # an existing gh-pages branch.
+            $branchExists = git ls-remote --heads origin gh-pages
+            if ($LASTEXITCODE -ne 0) {
+              # `throw` (not `exit 1`) so the outer try/finally cleanup runs and
+              # the global http.extraheader auth header is always unset.
+              throw "git ls-remote --heads origin gh-pages failed with exit code $LASTEXITCODE — aborting before we accidentally bootstrap over an existing gh-pages branch."
+            }
+            $useWorktree = [bool]$branchExists
+            if ($useWorktree) {
+              git fetch origin gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git fetch origin gh-pages failed with exit code $LASTEXITCODE" }
+              git show-ref --verify --quiet refs/heads/gh-pages
+              if ($LASTEXITCODE -ne 0) { git branch gh-pages origin/gh-pages }
+              git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+              if (Test-Path -LiteralPath $WORK_DIR) { Remove-Item -LiteralPath $WORK_DIR -Recurse -Force }
+              git worktree add $WORK_DIR gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git worktree add $WORK_DIR gh-pages failed with exit code $LASTEXITCODE" }
+            } else {
+              Write-Host "ℹ️ gh-pages does not exist yet — starting fresh."
+              New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
+              # Initialize an empty repo on the gh-pages branch so the later
+              # add/commit/push commands have a real git repository to operate on.
+              # Auth is provided by the global http.extraheader configured above,
+              # so the remote URL does not embed the token.
+              git -C $WORK_DIR init --initial-branch=gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git init in $WORK_DIR failed with exit code $LASTEXITCODE" }
+              git -C $WORK_DIR remote add origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
+              if ($LASTEXITCODE -ne 0) { throw "git remote add origin failed with exit code $LASTEXITCODE" }
+            }
+
+            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev.
+            # ('dev' is where benchmark-action/github-action-benchmark stores its
+            # chart + accumulated data.js — wiping it loses chart history on every release.)
+            # Gated on DEPLOY_AS_LATEST=true because the root is only repopulated
+            # (version-picker index.html, root versions.json, shared assets) in that
+            # branch below — a rebuild of an older version (deploy_as_latest=false)
+            # would otherwise strip the root and leave only /versions/<x>/ paths.
+            if ($env:DEPLOY_AS_LATEST -eq 'true') {
+              Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
+                $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
+              } | Remove-Item -Recurse -Force
+            } else {
+              Write-Host "Skipping root cleanup — DEPLOY_AS_LATEST is not 'true', preserving existing site root."
+            }
+
+            # Ensure .nojekyll exists so GitHub Pages does not run Jekyll
+            New-Item -ItemType File -Path (Join-Path $WORK_DIR '.nojekyll') -Force | Out-Null
+
+            # Deploy versioned docs (real DocFX index.html — before version picker
+            # overwrites it). Clear the destination first so files that were
+            # dropped from docfx output between releases don't linger forever.
+            $versionedDir = Join-Path $WORK_DIR "versions/$($env:VERSION_DIR)"
+            if (Test-Path -LiteralPath $versionedDir) {
+              Get-ChildItem -LiteralPath $versionedDir -Force | Remove-Item -Recurse -Force
+            } else {
+              New-Item -ItemType Directory -Force -Path $versionedDir | Out-Null
+            }
+            Copy-Item -Path "$siteDir/*" -Destination $versionedDir -Recurse -Force
+            Write-Host "✅ Copied docs to versions/$($env:VERSION_DIR)/"
+
+            if ($env:DEPLOY_AS_LATEST -eq 'true') {
+              # Deploy to versions/latest/ (real DocFX index.html). Same clear-
+              # before-copy pattern as versions/<dir> above to prevent stale
+              # files from previous releases lingering when docfx output shrinks.
+              $latestDir = Join-Path $WORK_DIR 'versions/latest'
+              if (Test-Path -LiteralPath $latestDir) {
+                Get-ChildItem -LiteralPath $latestDir -Force | Remove-Item -Recurse -Force
+              } else {
+                New-Item -ItemType Directory -Force -Path $latestDir | Out-Null
+              }
+              Copy-Item -Path "$siteDir/*" -Destination $latestDir -Recurse -Force
+              Write-Host "✅ Copied docs to versions/latest/"
+
+              # Generate version-picker index.html and overwrite _site/index.html.
+              # This happens AFTER the versioned copies above, so those directories
+              # retain the real DocFX landing page while the root gets the picker.
+              $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
+              $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
+              $versions = Get-Content "$siteDir/versions.json" -Raw | ConvertFrom-Json
+
+              $listItems = foreach ($v in $versions) {
+                $liClass = if ($v.version -eq 'latest') { ' class="latest"' } else { '' }
+                $label   = if ($v.version -eq 'latest') { 'latest (stable)' } else { $v.version }
+                "      <li${liClass}><a href=`"$($v.url)`">$label</a></li>"
+              }
+              $listHtml = $listItems -join "`n"
+
+              if (-not (Test-Path '.github/version-picker-template.html')) {
+                # `throw` (not `exit 1`) so the outer try/finally cleanup runs.
+                throw ".github/version-picker-template.html not found; cannot generate root index.html."
+              }
+
+              $template = Get-Content '.github/version-picker-template.html' -Raw
+              $html = $template -replace '\{\{TITLE\}\}', $title `
+                                -replace '\{\{VERSION_LIST\}\}', $listHtml
+              $html | Set-Content -Path "$siteDir/index.html" -Encoding utf8NoBOM
+              Write-Host "Generated version-picker index.html with $($versions.Count) version link(s)."
+
+              # Deploy version picker + shared assets to site root
+              Copy-Item -Path "$siteDir/*" -Destination $WORK_DIR -Recurse -Force
+              Write-Host "✅ Copied version picker to site root"
+            }
+
+            # Single commit and push.
+            # `git diff --cached --quiet` exits 0 (no changes), 1 (changes
+            # exist), or >1 (error — e.g. cannot read index). Treat the
+            # three cases explicitly: commit only when there are changes
+            # (exit 1); on >1 abort the deploy with a clear error; on 0
+            # report "nothing to deploy" and exit cleanly.
+            git -C $WORK_DIR add -A
+            git -C $WORK_DIR diff --cached --quiet
+            $diffExit = $LASTEXITCODE
+            if ($diffExit -eq 1) {
+              $msg = if ($env:DEPLOY_AS_LATEST -eq 'true') {
+                "docs: deploy $($env:VERSION_DIR) and update latest"
+              } else {
+                "docs: deploy $($env:VERSION_DIR)"
+              }
+              git -C $WORK_DIR commit -m $msg
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "❌ git commit failed with exit code $LASTEXITCODE — aborting deploy."
+                throw "git commit failed"
+              }
+              git -C $WORK_DIR push origin HEAD:gh-pages
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "❌ git push origin HEAD:gh-pages failed with exit code $LASTEXITCODE — deploy did not land."
+                throw "git push failed"
+              }
+              Write-Host "✅ Documentation deployed in a single commit."
+            } elseif ($diffExit -eq 0) {
+              Write-Host "ℹ️ No documentation changes to deploy."
+            } else {
+              Write-Error "❌ git diff --cached --quiet exited with $diffExit (error reading the staged index) — aborting deploy."
+              throw "git diff failed"
+            }
+
+            # Capture the deploy outcome before the finally block runs cleanup
+            # (which might overwrite $LASTEXITCODE with a benign value).
+            $deployExitCode = $LASTEXITCODE
           }
-          $listHtml = $listItems -join "`n"
+          finally {
+            if ($useWorktree) {
+              git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+            } elseif (Test-Path -LiteralPath $WORK_DIR) {
+              Remove-Item -LiteralPath $WORK_DIR -Recurse -Force -ErrorAction SilentlyContinue
+            }
 
-          if (Test-Path '.github/version-picker-template.html') {
-            $template = Get-Content '.github/version-picker-template.html' -Raw
-          } else {
-            Write-Host "Warning: .github/version-picker-template.html not found; using built-in default template."
-            exit 1
+            # ALWAYS unset the http.extraheader so the token (in encoded form)
+            # does not linger in the runner's global git config for any later
+            # step in this job, even if the try block hit an early `exit`.
+            git config --global --unset-all http."https://github.com/".extraheader 2>&1 | Out-Null
           }
 
-          $html = $template -replace '\{\{TITLE\}\}', $title `
-                            -replace '\{\{VERSION_LIST\}\}', $listHtml
-
-          $html | Set-Content -Path 'docfx_project/_site/index.html' -Encoding utf8NoBOM
-          Write-Host "Generated index.html with $($versions.Count) version link(s)."
-
-      - name: Deploy version picker to GitHub Pages root
-        # Publishes the version-picker index.html (generated above) to the site root ('/').
-        # keep_files: true preserves the versions/ folder and all its sub-folders.
-        # Skipped when deploy_as_latest is false (e.g. when rebuilding an older version).
-        if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docfx_project/_site
-          keep_files: true
-          force_orphan: false
+          # PowerShell will not propagate $LASTEXITCODE from a script block as
+          # the step's exit code reliably; explicitly `exit` so a failed
+          # commit/push fails the workflow step.
+          if ($deployExitCode -ne 0) {
+            exit $deployExitCode
+          }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,8 +9,8 @@
 # - All checkout steps use PR refs (refs/pull/*/head) to check out PR code from the base repo
 # - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
 #   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
-# - A separate "Protected File Check" job detects changes to these files and fails independently,
-#   without blocking Stages 1-3 from running. Add it to the branch ruleset to block merges.
+# - If a PR changes any of these protected configuration files, CI explicitly fails with instructions
+#   for a maintainer to manually review and verify the changes before merging
 # - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
 #   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
 # - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
@@ -48,12 +48,39 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Fetch trusted gitleaks config from main
+        # Prevent PR from modifying .gitleaks.toml to bypass the scan.
+        # Distinguish "file doesn't exist in main" (fine — gitleaks uses
+        # defaults) from "checkout failed for any other reason" (abort —
+        # silently using the PR version would defeat the guard).
+        shell: bash
+        run: |
+          if ! git fetch origin main --depth=1; then
+            echo "::error::Failed to fetch origin/main — aborting before gitleaks scan."
+            exit 1
+          fi
+          if git cat-file -e origin/main:.gitleaks.toml 2>/dev/null; then
+            if ! git checkout origin/main -- .gitleaks.toml; then
+              echo "::error::Failed to checkout origin/main:.gitleaks.toml — aborting to prevent silent fall-back to PR version."
+              exit 1
+            fi
+          else
+            echo "::notice::.gitleaks.toml not present in origin/main — gitleaks will use defaults."
+          fi
+
       - name: Run gitleaks
         # gitleaks-action@v2 does not support pull_request_target, so invoke the CLI directly
+        # Pinned to a specific version with SHA256 checksum verification for supply-chain safety
         run: |
           GITLEAKS_VERSION="8.24.0"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar xz -C /usr/local/bin gitleaks
+          GITLEAKS_SHA256="cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4"
+          mkdir -p "$HOME/.local/bin"
+          TARBALL="$(mktemp)"
+          curl -sSfL -o "$TARBALL" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c - || { echo "Checksum verification failed!"; exit 1; }
+          tar xzf "$TARBALL" -C "$HOME/.local/bin" gitleaks
+          rm -f "$TARBALL"
+          export PATH="$HOME/.local/bin:$PATH"
           gitleaks detect --source . --verbose --redact
         shell: bash
 
@@ -66,85 +93,122 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     outputs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
-
-      - name: Check for .NET project files
-        id: check-projects
+      
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
-            echo "has-projects=true" >> $GITHUB_OUTPUT
-            echo "✅ Found .NET project files - .NET build and test jobs will run"
-          else
-            echo "has-projects=false" >> $GITHUB_OUTPUT
-            echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
-          fi
-
-  # ============================================================================
-  # GUARD: Detect protected configuration file changes
-  # Runs independently so it never blocks Stages 1-3 from executing.
-  # Add this job's name to the branch ruleset required checks to block merges
-  # when protected files are changed without maintainer review.
-  # ============================================================================
-  check-protected-files:
-    name: "Protected File Check"
-    runs-on: ubuntu-latest
-    # Skip for Dependabot — its package-version bumps to protected files
-    # (e.g. Directory.Build.props analyzer references) are legitimate and
-    # the threat model of this guard is human PR authors disabling
-    # analyzers in their own PRs, not GitHub-controlled package bots.
-    # Required status checks treat skipped jobs as passing, so this lets
-    # Dependabot PRs auto-merge without a maintainer override.
-    if: |
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
-          fetch-depth: 0
-
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
+                fi
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+      
       - name: Detect protected configuration file changes
+        # Skip for Dependabot — its bumps to protected files (e.g. Directory.Build.props)
+        # are legitimate. The guard's threat model is human PR authors disabling analyzers
+        # in their own PRs; it does not apply to a trusted GitHub-controlled bot whose
+        # only action is package-version updates.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Checking for changes to protected configuration files in this PR..."
-
-          if ! git fetch origin main:main-branch; then
-            echo "❌ Failed to fetch base ref 'main'. Unable to compare protected files."
-            exit 1
-          fi
-
+          
+          # Verify main-branch ref is available (it was fetched in the previous step)
           if ! git cat-file -e main-branch 2>/dev/null; then
-            echo "❌ Base ref 'main-branch' not available after fetch."
+            echo "❌ main-branch ref not found - cannot detect configuration file changes"
             exit 1
           fi
-
+          
           changed_files=()
-
+          
+          # Check exact file matches against main branch git objects
+          # 2>/dev/null suppresses output when a file doesn't exist in one ref (new/deleted file),
+          # which git diff handles correctly via its exit code
           exact_files=(
             ".editorconfig"
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
           )
-
+          
           for config_file in "${exact_files[@]}"; do
             if ! git diff --quiet main-branch HEAD -- "$config_file" 2>/dev/null; then
               changed_files+=("$config_file")
             fi
           done
-
+          
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
+          # Including D so a PR that *deletes* a protected file (workflow,
+          # .globalconfig, .ruleset) also triggers the maintainer-review gate
+          # — a silent deletion is just as security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '\.(globalconfig|ruleset)$' || true)
-
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
             echo "⚠️  PROTECTED CONFIGURATION FILES CHANGED IN THIS PR:"
@@ -164,6 +228,17 @@ jobs:
           else
             echo "✅ No protected configuration files changed - CI fully validates this PR"
           fi
+      
+      - name: Check for .NET project files
+        id: check-projects
+        run: |
+          if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
+            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "✅ Found .NET project files - .NET build and test jobs will run"
+          else
+            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
+          fi
 
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
@@ -182,6 +257,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -196,74 +275,50 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -293,6 +348,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -349,10 +418,17 @@ jobs:
           for proj in "${projects[@]}"; do
             echo "Building: $proj"
             
-            # Extract target frameworks from the project file
-            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
-            # Collapse newlines so multi-line <TargetFrameworks> values are handled correctly
-            frameworks=$(tr '\n' ' ' < "$proj" | grep -oP '<TargetFramework[s]?>\s*\K[^<]+' | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp[0-9.]+|netstandard[0-9.]+)$' || true)
+            # Extract target frameworks via MSBuild property evaluation.
+            # This handles multi-line <TargetFrameworks> XML, conditional property groups,
+            # and TFMs inherited from Directory.Build.props — all of which break grep-based parsing.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp[0-9.]+|netstandard[0-9.]+)$' || true)
             
             if [ -z "$frameworks" ]; then
               echo "⚠️  No Linux-compatible frameworks found in $proj"
@@ -382,12 +458,32 @@ jobs:
 
       - name: Run tests with coverage (.NET Core 5.0 - 10.0)
         run: |
-          # Find all test projects (C#, VB.NET, F#)
-          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
-          
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          # The downstream coverage steps already handle the no-coverage-files case.
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
+          if [ ! -d ./tests ]; then
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
+          fi
+
+          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
           fi
           
           echo "=========================================="
@@ -401,9 +497,16 @@ jobs:
             echo "Testing project: $test_proj"
             echo "=========================================="
             
-            # Extract target frameworks from the project file
-            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
-            frameworks=$(grep -oP '<TargetFramework[s]?>\K[^<]+' "$test_proj" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp3\.1)$' || true)
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance — both break grep-based parsing).
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp3\.1)$' || true)
             
             if [ -z "$frameworks" ]; then
               echo "⊘ Skipping: No compatible .NET 5.0-10.0 target frameworks found"
@@ -422,7 +525,9 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=minimal" || exit 1
             done <<< "$frameworks"
@@ -466,15 +571,24 @@ jobs:
           
           failed_projects=""
           threshold=${CODECOV_MINIMUM:-90}
-          
+          matched_count=0
+
           while read -r line; do
-            # Match lines with module names and percentages
-            if echo "$line" | grep -qE '^[^ ].*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+            # Match lines with module names and percentages. The percent
+            # capture is the LAST %-suffixed number on the line, matching
+            # Stage 2's behavior — ReportGenerator Summary.txt rows often
+            # have line/branch/method columns and the overall figure is at
+            # end-of-line.
+            if echo "$line" | grep -qE '^[^ ].*[0-9]+(\.[0-9]+)?%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')
-              
+              # Floor the percent to int (matches Stage 2 pwsh's [int][math]::Floor)
+              # so we can use bash's integer -lt comparator below without
+              # erroring on decimals like "90.4".
+              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
+              matched_count=$((matched_count + 1))
+
               echo "Checking module: '$module' - Coverage: ${percent}%"
-              
+
               if [ "$percent" -lt "$threshold" ]; then
                 echo "  ❌ FAIL: Below ${threshold}% threshold"
                 failed_projects="$failed_projects $module (${percent}%)"
@@ -483,6 +597,14 @@ jobs:
               fi
             fi
           done < CoverageReport/Summary.txt
+
+          # Fail loudly when 0 modules matched - the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't parse coverage is worse than failing.
+          if [ "$matched_count" -eq 0 ]; then
+            echo "❌ Coverage parser matched 0 modules in Summary.txt - regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
+          fi
 
           if [ -n "$failed_projects" ]; then
             echo ""
@@ -536,6 +658,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -557,14 +683,14 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
           }
           
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -572,56 +698,11 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM
               }
             }
           }
           
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          foreach ($configFile in $configFiles) {
-            # Check if file exists in main branch
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
-              }
-            }
-          }
-
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
@@ -637,6 +718,20 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -647,12 +742,33 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          
+
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          # The coverage gate exists to enforce test coverage on shipping
+          # code. If ./src has projects but ./tests doesn't, fail loudly
+          # instead of silently passing the gate. Skip only for template-
+          # pack / in-dev repos that have no source projects yet.
+          $srcHasProjects = @(Get-ChildItem -Path './src' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' -ErrorAction SilentlyContinue).Count -gt 0
+
+          if (-not (Test-Path -Path './tests' -PathType Container)) {
+            if ($srcHasProjects) {
+              Write-Error "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
+          }
+
           $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
-          
+
           if (@($testProjects).Count -eq 0) {
-            Write-Error "❌ No test projects found in ./tests directory!"
-            exit 1
+            if ($srcHasProjects) {
+              Write-Error "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
           }
           
           Write-Host "==========================================" -ForegroundColor Cyan
@@ -700,13 +816,16 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build --no-restore `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=normal"
               } else {
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build --no-restore `
                   --logger "console;verbosity=normal"
               }
 
@@ -758,11 +877,34 @@ jobs:
 
           $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
           $failedProjects = @()
+          $matchedCount   = 0
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
-            if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+            # Only consider top-level assembly rows: non-space first char,
+            # then anything, then whitespace + the final percent at EOL.
+            # Matches Stage 1's `^[^ ].*[0-9]+(\.[0-9]+)?%$` filter (which
+            # uses awk $NF for the percent — robust to extra columns like
+            # line/branch/method that ReportGenerator can emit on the same
+            # row).
+            #
+            # Bug previously here: a `.*` between the module name and the
+            # trailing `(\d+)%` was greedy and could eat all but the last
+            # digit of the percent — turning "100" into "0" and failing
+            # the gate on actually-100%-covered modules. Two changes:
+            #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
+            #    (their parent assembly row carries the same number, so
+            #    nothing is lost — and Stage 1 ignores them too).
+            #  - Require whitespace immediately before the final `\d+%`
+            #    (`\s(\d+...)%\s*$`). This still allows intermediate
+            #    columns between the module name and the final percent
+            #    (the `.*` consumes them), but `.*` can't terminate
+            #    mid-digit-run — the regex engine MUST place `\s` before
+            #    the digits, which forces the last %-suffixed number on
+            #    the line to be captured intact.
+            if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
               $percent = [int][math]::Floor([double]$Matches[2])
+              $matchedCount++
 
               Write-Host "Checking module: '$module' - Coverage: ${percent}%"
 
@@ -773,6 +915,14 @@ jobs:
                 Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
               }
             }
+          }
+
+          # Fail loudly when 0 modules matched — the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't read coverage is worse than failing.
+          if ($matchedCount -eq 0) {
+            Write-Error "❌ Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
           }
 
           if ($failedProjects.Count -gt 0) {
@@ -819,6 +969,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -833,74 +987,50 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -913,6 +1043,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -969,10 +1113,16 @@ jobs:
           for proj in "${projects[@]}"; do
             echo "Building: $proj"
             
-            # Extract target frameworks from the project file
-            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
-            # Trim whitespace from each framework before filtering
-            frameworks=$(tr -d '\n\r' < "$proj" | sed -n -E 's/.*<TargetFrameworks?>[[:space:]]*>([^<]+)<\/TargetFrameworks?>.*/\1/p' | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance). Filter to .NET 6+ for macOS ARM64 compatibility.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
             
             if [ -z "$frameworks" ]; then
               echo "⚠️  No macOS ARM64-compatible frameworks found in $proj"
@@ -1002,15 +1152,34 @@ jobs:
 
       - name:  Run tests (.NET 6.0 - 10.0 only - ARM64 compatible)
         run: |
-          # Find all test projects (C#, VB.NET, F#)
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
+          if [ ! -d ./tests ]; then
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
+          fi
+
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)          
-          
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
+            exit 0
           fi
           
           echo "=========================================="
@@ -1024,11 +1193,16 @@ jobs:
             echo "Testing project: $test_proj"
             echo "=========================================="
             
-            # Extract target frameworks from the project file
-            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
-            # Only include .NET 6.0+ (ARM64 compatible on macOS)
-            # Normalize line endings to handle multi-line <TargetFramework> / <TargetFrameworks> elements
-            frameworks=$(tr -d '\n\r' < "$test_proj" | grep -Eo '<TargetFrameworks?>[^<]+' | sed -E 's/<TargetFrameworks?>//' | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance). Filter to .NET 6+ for macOS ARM64 compatibility.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
             
             if [ -z "$frameworks" ]; then
               echo "⊘ Skipping: No compatible .NET 6.0-10.0 target frameworks found (ARM64 required)"
@@ -1048,7 +1222,9 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=normal" || exit 1
             done <<< "$frameworks"
@@ -1071,8 +1247,17 @@ jobs:
 
       - name: Enforce 90% coverage threshold
         run: |
+          # If no cobertura files were produced (no tests, all test projects
+          # skipped, etc.), the preceding step explicitly skipped report
+          # generation. Mirror that here — gating only when coverage was
+          # actually collected — instead of failing with "Coverage report
+          # not generated!" on jobs that legitimately had nothing to cover.
+          if ! find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null | grep -q .; then
+            echo "ℹ️  No coverage files produced — skipping coverage gate (consistent with the prior 'skipping report generation' notice)."
+            exit 0
+          fi
           if [ ! -f "CoverageReport/Summary.txt" ]; then
-            echo "❌ Coverage report not generated!"
+            echo "❌ Coverage files exist but Summary.txt is missing — ReportGenerator failed."
             exit 1
           fi
 
@@ -1171,6 +1356,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -1185,74 +1374,50 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,65 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release tag matches csproj version
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip leading 'v' or 'v.' from the tag (v0.3.0 -> 0.3.0, v.0.1.0 -> 0.1.0)
+          $tagName = $env:RELEASE_TAG_NAME
+          $tagVersion = $tagName -replace '^v\.?', ''
+          Write-Host "Release tag:      $tagName" -ForegroundColor Cyan
+          Write-Host "Expected version: $tagVersion" -ForegroundColor Cyan
+          Write-Host ""
+
+          $srcCsprojs = @(Get-ChildItem -Path './src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+          if ($srcCsprojs.Count -eq 0) {
+            Write-Warning "No src csprojs found - skipping version validation"
+            exit 0
+          }
+
+          # Collect <Version> and <PackageVersion> values from every src csproj
+          $found = @()
+          foreach ($proj in $srcCsprojs) {
+            try {
+              [xml]$xml = Get-Content $proj.FullName -Raw
+              $nodes = $xml.SelectNodes('//Version | //PackageVersion')
+              foreach ($node in $nodes) {
+                $v = $node.InnerText.Trim()
+                if ($v) {
+                  $found += [pscustomobject]@{ Project = $proj.Name; Version = $v }
+                }
+              }
+            } catch {
+              Write-Warning "Failed to parse $($proj.Name): $($_.Exception.Message)"
+            }
+          }
+
+          Write-Host "Versions found in src csprojs:" -ForegroundColor Cyan
+          foreach ($f in $found) {
+            Write-Host "  $($f.Project): $($f.Version)" -ForegroundColor DarkGray
+          }
+          Write-Host ""
+
+          if ($found.Count -eq 0) {
+            Write-Error "No <Version> or <PackageVersion> found in any src csproj"
+            exit 1
+          }
+
+          if ($found.Version -contains $tagVersion) {
+            Write-Host "Release tag matches at least one src csproj version" -ForegroundColor Green
+          } else {
+            $allVersions = ($found.Version | Sort-Object -Unique) -join ', '
+            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match any src csproj version. Found: $allVersions. Bump the csproj <Version> or correct the release tag before re-running."
+            exit 1
+          }
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -300,6 +355,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -506,10 +562,107 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
+  # Verify the documentation builds cleanly BEFORE publishing the release —
+  # initiative D8. Builds DocFX without deploying so a docs failure blocks
+  # publish-nuget rather than landing after the package is already live.
+  verify-docs-build:
+    name: Verify Documentation Builds
+    runs-on: windows-latest
+    # Gate on the prior validation jobs so we don't burn ~5-10 min of Windows
+    # runner time on a release that's already failing earlier in the pipeline.
+    needs: [validate-release, pack-and-validate]
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Detect docfx project
+        id: check
+        shell: pwsh
+        run: |
+          if (Test-Path "docfx_project/docfx.json") {
+            "found=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          } else {
+            Write-Host "::notice::No docfx_project/docfx.json - skipping docs verification."
+            "found=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          # Install the same SDK set as validate-release so dotnet build can
+          # compile every TFM the solution targets (some test projects span
+          # netcoreapp3.1 → net10.0). Without these, the docs verify step
+          # fails on repos with broad multi-targeting.
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore .NET workloads
+        # Same gated probe as pr.yaml — only run dotnet workload restore when
+        # at least one csproj declares a workload-bearing TFM. Required for
+        # repos with MAUI/Android/iOS targets (e.g. Hawsey); fast no-op
+        # otherwise. Without this, dotnet build below fails on workload-bearing
+        # projects because the SDK can't resolve the workload assemblies.
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
+
+      - name: Restore dependencies
+        if: steps.check.outputs.found == 'true'
+        run: dotnet restore
+
+      - name: Build solution (Release)
+        if: steps.check.outputs.found == 'true'
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Install DocFX
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        run: dotnet tool update docfx --global || dotnet tool install docfx --global
+
+      - name: Build DocFX metadata
+        if: steps.check.outputs.found == 'true'
+        run: docfx metadata
+        working-directory: docfx_project
+
+      - name: Build documentation (no deploy)
+        if: steps.check.outputs.found == 'true'
+        run: docfx build
+        working-directory: docfx_project
+
+      - name: Verify documentation output
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        run: |
+          if (-Not (Test-Path "docfx_project/_site")) {
+            Write-Error "docfx_project/_site not found after build"
+            exit 1
+          }
+          if (-Not (Test-Path "docfx_project/_site/api")) {
+            Write-Error "docfx_project/_site/api not found - API metadata generation may have failed"
+            exit 1
+          }
+          Write-Host "Documentation built successfully - release may proceed"
+
   # Publish to NuGet (only if validation passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: pack-and-validate
+    needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     steps:
@@ -517,6 +670,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -612,11 +766,12 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
             ./nuget-packages/*.nupkg
+            ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
             release-coverage.zip
 

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,0 +1,107 @@
+# Stryker mutation testing
+#
+# Runs the Stryker.NET mutation tester against the repo's test projects to
+# measure mutation score. Mutation runs are slow — triggered manually
+# (workflow_dispatch) and on a weekly schedule, not on every PR.
+#
+# The workflow looks for a stryker-config.json at the repo root or under
+# tests/**/. If none is present the run is a no-op (Stryker setup is a
+# per-repo follow-up; this file is the canonical infrastructure).
+name: Stryker (mutation testing)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Run Stryker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Detect stryker-config.json
+        id: check
+        shell: bash
+        run: |
+          # Explicit existence checks rather than globbing — `nullglob` only
+          # drops words that look like patterns (contain *, ?, [). The bare
+          # literal `stryker-config.json` has no glob characters, so it would
+          # be preserved as a literal even when the file doesn't exist, and
+          # the workflow would mistakenly think a config was present.
+          shopt -s globstar nullglob
+          configs=()
+          [ -f stryker-config.json ] && configs+=(stryker-config.json)
+          for cfg in tests/**/stryker-config.json; do
+            [ -f "$cfg" ] && configs+=("$cfg")
+          done
+          if (( ${#configs[@]} )); then
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            # NOTE: previously also wrote a configs<<EOF multi-line output here,
+            # but (a) the downstream Run Stryker step re-globs from scratch and
+            # didn't consume it, and (b) ${configs[*]} joins with spaces so the
+            # value was effectively a single space-separated line — not actually
+            # multi-line. Dropped the dead/broken output.
+          else
+            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
+            printf 'found=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-stryker
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
+
+      - name: Run Stryker
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          # Run BOTH a root stryker-config.json (if present) AND any
+          # tests/**/stryker-config.json suites. The Detect step collects
+          # both shapes; running only one leaves per-test suites unscanned
+          # in repos that have both an umbrella and per-suite configs.
+          ran=0
+          if [ -f stryker-config.json ]; then
+            echo "::group::Stryker with root stryker-config.json"
+            dotnet stryker --config-file stryker-config.json
+            echo "::endgroup::"
+            ran=1
+          fi
+          for cfg in tests/**/stryker-config.json; do
+            dir=$(dirname "$cfg")
+            echo "::group::Stryker in $dir"
+            (cd "$dir" && dotnet stryker)
+            echo "::endgroup::"
+            ran=1
+          done
+          if [ "$ran" -eq 0 ]; then
+            echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
+            exit 1
+          fi
+
+      - name: Upload Stryker report
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: |
+            **/StrykerOutput/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,4 +1,4 @@
-# BannedSymbols.txt - Async-First Enforcement for Wolfgang.D20-Dice
+# BannedSymbols.txt - Async-First Enforcement for Wolfgang.D20.Dice
 # Format: <API Documentation ID>; <Reason/Alternative>
 # T: = Type, M: = Method, P: = Property, F: = Field
 # Task.Wait() - All overloads - Absolutely NOT allowed in async code
@@ -79,4 +79,3 @@ M:System.Console.ReadLine(); Blocking - avoid in async code paths
 M:System.Console.Read(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(System.Boolean); Blocking - avoid in async code paths
-

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,14 @@
 <Project>
   <PropertyGroup>
+    <!-- Enable nullable reference types for every SDK-style C# project.
+         The condition excludes:
+           - F# (.fsproj) and VB (.vbproj) — by the .csproj check
+           - Legacy non-SDK csproj (no Microsoft.NET.Sdk import) — by the
+             $(UsingMicrosoftNETSdk) check
+         SDK-style C# projects that need to opt out can set
+         <Nullable>disable</Nullable> in their own csproj. -->
+    <Nullable Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(UsingMicrosoftNETSdk)' == 'true'">enable</Nullable>
+
     <!-- Enable .NET analyzers -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -52,6 +61,51 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.26.0.140279">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
+         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
+         project directory and the analyzer activates for that project only.
+         Library projects under src/ should opt in; test / example /
+         benchmark projects should not. Per-repo enablement is tracked as a
+         follow-up maintenance issue. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" Condition="Exists('PublicAPI.Shipped.txt')" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI.Unshipped.txt')" />
+  </ItemGroup>
+
+
+  <PropertyGroup>
+    <!-- CI3: NuGet package metadata canonical defaults. Per-repo fields
+         (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
+         PackageLicenseExpression, PackageReadmeFile) stay in each src
+         csproj where they are repo-specific. -->
+    <Authors>Chris Wolfgang</Authors>
+    <Company>Chris Wolfgang</Company>
+    <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SourceLink: embed source provenance into PDBs so debuggers can step
+         into NuGet package code from GitHub. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,24 @@
+# Benchmark-project analyzer carve-outs (canonical).
+#
+# Benchmark projects inherit `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
+# from the root `Directory.Build.props` in Release builds — same bar as
+# src/ and tests/. BenchmarkDotNet code patterns (deliberately naive
+# measured code, `[Benchmark]` methods invoked by reflection, fields
+# mutated by harness, etc.) can trip some analyzer rules that would
+# otherwise be reasonable.
+#
+# This file is the canonical home for benchmark-inappropriate
+# analyzer suppressions. As BDN-typical warnings surface during
+# benchmark expansion, add per-rule severity overrides BELOW the
+# `[*.cs]` section header rather than blanket-disabling TWEA on
+# the folder. Properties placed before any section header are
+# ignored by most EditorConfig parsers — keep entries inside
+# `[*.cs]`.
+
+[*.cs]
+
+# Examples (commented out — none required yet for this repo):
+# dotnet_diagnostic.CA1822.severity = none      # methods don't access this
+# dotnet_diagnostic.MA0048.severity = none      # File name does not match
+# dotnet_diagnostic.S1144.severity  = none      # Unused private members (reflection)
+# dotnet_diagnostic.S2933.severity  = none      # Fields used by reflection should be private

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,48 @@
+# Analyzer rules relaxed for test projects
+
+[*.cs]
+
+# AsyncFixer01: Remove async/await for single-expression methods — test methods need async for Assert.ThrowsAsync
+dotnet_diagnostic.AsyncFixer01.severity = none
+
+# MA0004: Use ConfigureAwait(false) — not needed in test code
+dotnet_diagnostic.MA0004.severity = none
+
+# MA0011: Use IFormatProvider overload of ToString — not needed in test assertions
+dotnet_diagnostic.MA0011.severity = none
+
+# MA0048: File name must match type name — test files contain multiple helper types
+dotnet_diagnostic.MA0048.severity = none
+
+# MA0051: Method is too long — test methods can be longer for readability
+dotnet_diagnostic.MA0051.severity = none
+
+# MA0074: Use StringComparison overload — not critical in tests
+dotnet_diagnostic.MA0074.severity = none
+
+# S108: Empty block of code — sometimes needed in test setup
+dotnet_diagnostic.S108.severity = none
+
+# S1215: Remove use of GC.GetTotalMemory — acceptable in perf/memory tests
+dotnet_diagnostic.S1215.severity = none
+
+# S2699: Add assertion to test case — some tests verify no-throw behavior
+dotnet_diagnostic.S2699.severity = none
+
+# S6562: Provide DateTimeKind — test data doesn't need DateTimeKind
+dotnet_diagnostic.S6562.severity = none
+
+# S6610: Use char overload of StartsWith — not critical in tests
+dotnet_diagnostic.S6610.severity = none
+
+# VSTHRD200: Use Async suffix — test methods follow xunit naming conventions
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# MA0003: Name the parameter — not needed in test assertions and setup
+dotnet_diagnostic.MA0003.severity = none
+
+# S1144: Remove unused private type member — test POCOs have constructors used via reflection
+dotnet_diagnostic.S1144.severity = none
+
+# xUnit2013: Use Assert.Single instead of Assert.Equal for collection size
+dotnet_diagnostic.xUnit2013.severity = none


### PR DESCRIPTION
## Summary

Extracts just the protected files from the v0.5.1 release branch (vNext, PR #144) so the admin-bypass merge can be scoped to the 12 protected paths the Detect .NET Projects / Protected File Check guard cares about. After this lands on `main`, PR #144 will only show unprotected drift and can merge without bypass.

This is the standard `protected-file-pr-split` pattern from the per-repo-release-pilot skill, applied to D20-Dice's vNext release.

## Protected files (12)

| File | Reason it's protected |
|---|---|
| `.editorconfig` | global EditorConfig — canonical sync |
| `BannedSymbols.txt` | banned-API analyzer baseline |
| `Directory.Build.props` | global MSBuild props (analyzer set, DBP-Nullable, CI3 metadata, SourceLink, snupkg, EmbedUntrackedSources) |
| `benchmarks/.editorconfig` | **new** — canonical placement for BDN rule carve-outs (issue #134) |
| `tests/.editorconfig` | canonical test-rule carve-outs |
| `.github/workflows/pr.yaml` | per-PR validation (Stage 1/2/3) |
| `.github/workflows/release.yaml` | D8 `verify-docs-build` job |
| `.github/workflows/docfx.yaml` | D6 versions.json preservation guard + T1 coverage |
| `.github/workflows/codeql.yaml` | S1 security-extended query pack |
| `.github/workflows/build-all-versions.yaml` | docs deploy pin bump |
| `.github/workflows/stryker.yaml` | **new** — T3 mutation testing |
| `.github/workflows/benchmarks.yaml` | **new** — P2 BDN → gh-pages chart |

## Merge sequence

1. **Admin-bypass merge this PR** to land the protected files on main
2. Merge main back into the v0.5.1 vNext branch (PR #144) — done automatically via `gh pr update-branch` or one local merge + push
3. PR #144 will then show only unprotected diff and is mergeable without bypass
4. Merge PR #144 normally → v0.5.1 ships per the standard per-repo release pilot flow