### PR TITLE
C5: AI code-review pass on Dice.cs + IDice.cs (closes #110)

### DIFF
--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -77,7 +77,7 @@ public sealed class Dice : IDice, IEquatable<Dice>, IEqualityComparer<Dice>
         {
             checked
             {
-                return (DieCount * 1) + Modifier;
+                return DieCount + Modifier;
             }
         }
     }
@@ -103,7 +103,10 @@ public sealed class Dice : IDice, IEquatable<Dice>, IEqualityComparer<Dice>
     /// <summary>
     /// Rolls the dice and returns the total value rolled, including any modifier.
     /// </summary>
-    /// <returns>int</returns>
+    /// <returns>
+    /// The sum of <see cref="DieCount"/> independent uniform rolls in [1, <see cref="SideCount"/>] plus <see cref="Modifier"/>.
+    /// Always between <see cref="MinValue"/> and <see cref="MaxValue"/> inclusive.
+    /// </returns>
     public int Roll()
     {
 #if NET6_0_OR_GREATER
@@ -130,10 +133,10 @@ public sealed class Dice : IDice, IEquatable<Dice>, IEqualityComparer<Dice>
     /// y is the number of sides on each die,
     /// z is the modifier (if any).
     /// </summary>
-    /// <returns>string</returns>
-    /// <remarks>
-    /// If the modifier is 0, it is omitted from the string.
-    /// </remarks>
+    /// <returns>
+    /// The dice in standard <c>XdY+Z</c> notation; the modifier is omitted when zero, and a negative modifier
+    /// renders as <c>XdY-Z</c> (the sign is part of the modifier token).
+    /// </returns>
     public override string ToString()
     {
         var value = $"{DieCount}d{SideCount}";
@@ -216,55 +219,39 @@ public sealed class Dice : IDice, IEquatable<Dice>, IEqualityComparer<Dice>
         {
             return true;
         }
-
-        if (x is null)
+        if (x is null || y is null)
         {
             return false;
         }
-
-        if (y is null)
-        {
-            return false;
-        }
-
-        if (x.GetType() != y.GetType())
-        {
-            return false;
-        }
-
-        return x.DieCount == y.DieCount && x.SideCount == y.SideCount && x.Modifier == y.Modifier;
+        // GetType check unnecessary — Dice is sealed, so x and y are always exactly Dice.
+        return x.Equals(y);
     }
 
 
 
     /// <summary>
-    /// Generates a hash code for this instance based on its DieCount, SideCount, and Modifier.
+    /// Generates a hash code for the supplied <see cref="Dice"/> instance based on its <see cref="DieCount"/>,
+    /// <see cref="SideCount"/>, and <see cref="Modifier"/>. <see cref="IEqualityComparer{T}"/> implementation.
     /// </summary>
-    /// <param name="obj">The <see cref="Dice"/> instance for which to generate the hash code.</param>
-    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="obj"/> is null.</exception>
-    /// <returns>int</returns>
+    /// <param name="obj">The <see cref="Dice"/> instance to hash.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
+    /// <returns>A combined hash code of the three identity properties.</returns>
     public int GetHashCode(Dice obj)
     {
         if (obj == null)
         {
             throw new ArgumentNullException(nameof(obj));
         }
-
-        unchecked
-        {
-            var hashCode = obj.DieCount;
-            hashCode = (hashCode * 397) ^ obj.SideCount;
-            hashCode = (hashCode * 397) ^ obj.Modifier;
-            return hashCode;
-        }
+        return obj.GetHashCode();
     }
 
 
 
     /// <summary>
-    /// Generates a hash code for this instance based on its DieCount, SideCount, and Modifier.
+    /// Generates a hash code for this instance based on its <see cref="DieCount"/>, <see cref="SideCount"/>,
+    /// and <see cref="Modifier"/>.
     /// </summary>
-    /// <returns>int</returns>
+    /// <returns>A combined hash code of the three identity properties.</returns>
     public override int GetHashCode()
     {
 #if NET5_0_OR_GREATER

--- a/src/Wolfgang.D20.Dice/IDice.cs
+++ b/src/Wolfgang.D20.Dice/IDice.cs
@@ -1,7 +1,7 @@
 namespace Wolfgang.D20;
 
 /// <summary>
-/// Represents a number of dice, each with the name specified number of sides and optional modifier.
+/// Represents a number of dice, each with the specified number of sides and an optional modifier.
 /// </summary>
 public interface IDice
 {
@@ -45,21 +45,24 @@ public interface IDice
     /// <summary>
     /// Rolls the dice and returns the total value rolled, including any modifier.
     /// </summary>
-    /// <returns>int</returns>
+    /// <returns>
+    /// The sum of <see cref="DieCount"/> independent uniform rolls in [1, <see cref="SideCount"/>] plus <see cref="Modifier"/>.
+    /// Always between <see cref="MinValue"/> and <see cref="MaxValue"/> inclusive.
+    /// </returns>
     int Roll();
 
 
 
     /// <summary>
     /// Returns a string representation of the dice in the format "XdY+Z" where:
-    /// x is the number of dice,
-    /// y is the number of sides on each die,
-    /// z is the modifier (if any).
+    /// X is the number of dice,
+    /// Y is the number of sides on each die,
+    /// Z is the modifier (if any).
     /// </summary>
-    /// <returns>string</returns>
-    /// <remarks>
-    /// If the modifier is 0, it is omitted from the string.
-    /// </remarks>
+    /// <returns>
+    /// The dice in standard <c>XdY+Z</c> notation; the modifier is omitted when zero, and a negative modifier
+    /// renders as <c>XdY-Z</c>.
+    /// </returns>
     string ToString();
 
 }


### PR DESCRIPTION
## Summary

Surface-only review pass on the (small) library — `Dice.cs` (413 lines) and `IDice.cs` (65 lines). All 83 existing tests still pass across all 12 TFMs locally. No behaviour or public-API changes.

## Findings + fixes

### `Dice.cs`

| Finding | Fix |
|---|---|
| `MinValue` uses `(DieCount * 1) + Modifier` | Removed the dead `* 1` — now plain `DieCount + Modifier`. |
| `Equals(Dice? x, Dice? y)` (the `IEqualityComparer<Dice>` impl) duplicated all the property-comparison logic from `Equals(Dice?)` | Collapsed to delegate to `Equals(Dice?)` after the null / ref-equals checks. Removed the dead `x.GetType() != y.GetType()` guard — `Dice` is `sealed`, so x and y are always exactly `Dice`. |
| `GetHashCode(Dice obj)` duplicated the prime-397 logic from the instance `GetHashCode()` | Delegated to `obj.GetHashCode()` instead. The instance `GetHashCode()` retains the conditional `HashCode.Combine` (net5+) / prime-397 (older TFMs) so the per-TFM branching stays in one place. |
| `<returns>int</returns>` / `<returns>string</returns>` on `Roll()` / `ToString()` / both `GetHashCode()` overloads | Replaced the type-name stubs with semantic descriptions including `<see cref>` anchors back to the relevant properties. |

### `IDice.cs`

| Finding | Fix |
|---|---|
| Type `<summary>` had a typo: *"with the **name** specified number of sides"* | Removed — now "with the specified number of sides". |
| Same `<returns>` stubs on `Roll()` / `ToString()` | Same replacement with semantic descriptions. |
| `ToString` `<summary>` had lower-case `x`/`y`/`z` describing the format | Normalised to upper-case `X`/`Y`/`Z` — the standard form is `XdY+Z`. |

## Not changed (out of scope for this pass)

- **`SharedRandom` thread-safety on older TFMs.** Pre-`net6.0`, the static `new Random()` field is shared across threads but `Random` isn't thread-safe. Concurrent `Roll()` calls from different threads could corrupt internal state. Fixing would change behaviour (introduce a lock or per-thread instance) and warrants its own design discussion — flagged as a follow-up if randomness fairness under concurrency becomes a concern.
- **Multi-modifier regex** `(?<modifier>[+-]\d+)*` — the trailing `*` allows `1d6+2+3` (summed). Intentional per `TryGetModifierTotal`; whether to document it publicly is a separate question.
- **`TryParse` error-message punctuation consistency** — minor cosmetic; not worth the noise in a code-review PR.

Stacked on top of vNext (PR #144 / #148).