### PR TITLE
T4: audit test quality (closes #139)

### DIFF
--- a/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
@@ -91,15 +91,16 @@ public class DiceTests
 
 
 
-    [Fact]
-    public void Modify_can_be_positive_or_negative()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void Modifier_can_be_positive_zero_or_negative_including_int_boundaries(int modifier)
     {
-        _ = new Dice(modifier: 0);
-        _ = new Dice(modifier: 1);
-        _ = new Dice(modifier: -1);
-        _ = new Dice(modifier: int.MinValue);
-        _ = new Dice(modifier: int.MaxValue);
-        Assert.True(true);
+        var dice = new Dice(modifier: modifier);
+        Assert.Equal(modifier, dice.Modifier);
     }
 
 


### PR DESCRIPTION
## Summary

Audited `DiceTests.cs` (55 tests / 709 lines) and applied one concrete fix; documented the rest as a list of small mechanical improvements for review-and-apply later.

## Applied in this PR

**One real test was a no-op** — `Modify_can_be_positive_or_negative` constructed 5 `Dice` instances and ended with `Assert.True(true)`, which would pass even if the constructor silently dropped the modifier. Converted to a `[Theory]` with 5 `[InlineData]` rows and a real `Assert.Equal(modifier, dice.Modifier)` assertion. Also corrected the spelling (`Modify_` → `Modifier_`).

Test count goes from 55 unique method bodies to 59 (1 `[Fact]` → 1 `[Theory]` × 5 rows). Build clean, all tests pass across 12 TFMs.

## Documented but NOT applied — see `docs/TEST-AUDIT.md`

Per the repo policy of *flag test changes for review before committing*, the following sit as findings for you to decide on:

1. **5 `Assert.True(x.Equals(y))` calls** that would produce better failure messages as `Assert.Equal(y, x)` (which shows a diff instead of just `Expected: True / Actual: False`)
2. **11 `Assert.False(...Equals...)` calls** likewise convertible to `Assert.NotEqual`
3. **Test naming inconsistency** — most tests follow `MethodUnderTest_when_condition_expected_result` per CLAUDE.md; the newer `EqualsDice_*` / `EqualsObject_*` tests (lines 370-509) use PascalCase `Scenario_Expected`. One style or the other across the file.

## Findings noted but not actionable

- **`Assert.True(result.Succeeded)` / `Failed`** patterns are fine — `Result<T>` doesn't have equality semantics that would benefit from `Assert.Equal`.
- **Magic numbers** are domain-appropriate (`int.MinValue`, the dice parameters); no extraction needed.
- **Boundary coverage** is strong — dieCount/sideCount ranges, int boundaries on modifier, equality semantics, all covered.
- **xunit version** is 2.9.3 + runner 2.8.2 — compliant with repo convention.
- **No shared mutable state, no reflection-into-internals, no `[MemberData]` opportunities.**

See `docs/TEST-AUDIT.md` for the full audit doc.

Stacked on top of vNext (PR #144 / #148).