### PR TITLE
fix: 'obj == null' → 'obj is null' for consistency (orphan rescue)

### DIFF
--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -238,7 +238,7 @@ public sealed class Dice : IDice, IEquatable<Dice>, IEqualityComparer<Dice>
     /// <returns>A combined hash code of the three identity properties.</returns>
     public int GetHashCode(Dice obj)
     {
-        if (obj == null)
+        if (obj is null)
         {
             throw new ArgumentNullException(nameof(obj));
         }


### PR DESCRIPTION
Rescues the orphan one-line fix from PR #149's branch that was pushed after the squash-merge to vNext, so didn't propagate to main with the rest of the C5 review pass.

`Dice.GetHashCode(Dice obj)` was using `if (obj == null)` — every other null check in the file uses pattern-matching `is null`. Switching to `is null` matches the file convention and avoids the (theoretical-here) risk that a future overload of `==` would intercept the null check.

This is the only remaining cleanup from #149's Copilot review — landing it post-release rather than blocking the v0.5.1 tag.