### PR TITLE
docfx.json: include picker assets in build + bootstrap script (canonical sync)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -33,7 +33,9 @@
       {
         "files": [
           "logo.svg",
-          "images/**"
+          "images/**",
+          "public/**",
+          "versions.json"
         ]
       }
     ],
@@ -44,11 +46,11 @@
       "modern"
     ],
     "globalMetadata": {
-      "_appName": "Wolfgang.D20-Dice",
-      "_appTitle": "Wolfgang.D20-Dice Documentation",
+      "_appName": "Wolfgang.D20.Dice",
+      "_appTitle": "Wolfgang.D20.Dice Documentation",
       "_appLogoPath": "logo.svg",
       "_enableSearch": true,
-      "_appFooter": "Made with DocFX",
+      "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,
       "_disableTocFilter": false,
       "_enableDarkMode": true,


### PR DESCRIPTION
## Summary

Three canonical fixes to `docfx_project/docfx.json` so the version picker actually renders on the deployed site. Diagnosed when the planned v0.5.1 redeploy (via PR #156's overlay) ran successfully but the deployed page still had no picker.

## Root cause

PR #155 added `docfx_project/public/version-picker.js` and `docfx_project/versions.json` to the repo, but `docfx.json` was never updated to:
1. **Copy the picker assets to `_site/` during build** — without `public/**` and `versions.json` in the `resource.files` list, docfx silently doesn't include them in the output.
2. **Bootstrap the picker on every page** — without a `<script>` tag in `_appFooter` that dynamically loads `/public/version-picker.js`, no page ever calls into the picker code even when the JS is present.

Both of those changes are in the canonical `repo-template/docfx_project/docfx.json` but were never applied to D20-Dice (since docfx.json wasn't in the protected-files canonical sync).

## Three changes

| | Was | Now |
|---|---|---|
| `resource.files` | `logo.svg`, `images/**` | `logo.svg`, `images/**`, **`public/**`**, **`versions.json`** |
| `_appFooter` | `"Made with DocFX"` | `"Made with DocFX <script>...(dynamic loader for /public/version-picker.js)...</script>"` |
| `_appName` / `_appTitle` | `Wolfgang.D20-Dice` (hyphen — repo name) | `Wolfgang.D20.Dice` (dot — package id) — matches the D5 markdown audit fixes from PR #146 |

## After merge

1. The push-to-main triggers nothing automatically (docfx.yaml fires on `workflow_call` from release.yaml or on `workflow_dispatch`)
2. Re-run `gh workflow run docfx.yaml -R Chris-Wolfgang/D20-Dice -f version=v0.5.1` to rebuild and redeploy v0.5.1's docs with the picker now actually included in the build
3. Verify `https://chris-wolfgang.github.io/D20-Dice/versions/v0.5.1/public/version-picker.js` is no longer 404
4. Open any docs page → version dropdown should appear in the page footer

## Not protected

`docfx_project/docfx.json` isn't in the protected-paths list. Normal merge — no admin bypass needed.