### PR TITLE
Sync version-picker-template.html to canonical (meta-refresh redirect)

### DIFF
--- a/.github/version-picker-template.html
+++ b/.github/version-picker-template.html
@@ -4,6 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{TITLE}}</title>
+
+  <!-- Auto-redirect to the latest version of the docs.
+       The in-page version picker (docfx_project/public/version-picker.js)
+       lets readers switch versions from any page once they land there, so
+       the root no longer needs to be a "pick a version" landing page —
+       a redirect to /versions/latest/ is the desired UX.
+
+       meta-refresh works without JavaScript; the JS fallback below kicks
+       in if the meta-refresh is blocked by some agent. Visible text +
+       <noscript> link covers everything else. -->
+  <meta http-equiv="refresh" content="0; url=versions/latest/">
+  <link rel="canonical" href="versions/latest/">
+
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -12,28 +25,34 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      justify-content: center;
       padding: 3rem 1rem;
       min-height: 100vh;
       margin: 0;
+      text-align: center;
     }
-    h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #cba6f7; }
-    p  { color: #a6adc8; margin-bottom: 2rem; }
-    ul { list-style: none; padding: 0; width: 100%; max-width: 480px; }
-    li a {
-      display: block; padding: 0.75rem 1.25rem; margin-bottom: 0.5rem;
-      border-radius: 6px; background: #313244; color: #89b4fa;
-      text-decoration: none; font-size: 1.05rem; transition: background 0.15s;
-    }
-    li a:hover { background: #45475a; }
-    li.latest a { background: #1e66f5; color: #fff; font-weight: bold; }
-    li.latest a:hover { background: #1959d9; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #cba6f7; }
+    a  { color: #89b4fa; }
   </style>
+  <script>
+    // Backup redirect in case meta-refresh is suppressed.
+    setTimeout(function () {
+      window.location.replace('versions/latest/');
+    }, 50);
+  </script>
 </head>
 <body>
   <h1>{{TITLE}}</h1>
-  <p>Select a documentation version:</p>
-  <ul>
-{{VERSION_LIST}}
-  </ul>
+  <p>Redirecting to the <a href="versions/latest/">latest documentation</a>&hellip;</p>
+  <noscript>
+    <p>JavaScript is disabled. <a href="versions/latest/">Click here</a> to continue.</p>
+  </noscript>
+  <!-- The docfx.yaml workflow's substitution still looks for {{VERSION_LIST}}
+       but the placeholder is intentionally omitted from this template: a
+       missing pattern is a true no-op for PowerShell's `-replace` (returns
+       the original string unchanged). The in-page <select> dropdown shipped
+       in docfx_project/public/version-picker.js is now the canonical
+       version-selector UI, so no list of links needs to be rendered into
+       the root redirect page. -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

D20-Dice's `.github/version-picker-template.html` was the older version that produces a 'pick a version' landing page with a visible `<ul>` of links. The canonical (used by DateTime-Extensions and other repos) replaces that with a meta-refresh redirect to `/versions/latest/` plus a JS fallback. The visible-list pattern is redundant now that the in-page version-picker dropdown (wired up by PRs #155 / #157) is in every docs page.

## What changes on the deployed site

**Before:** `chris-wolfgang.github.io/D20-Dice/` shows a static landing page with a list of versions to click.

**After:** `chris-wolfgang.github.io/D20-Dice/` immediately redirects to `/versions/latest/` (the same canonical landing experience DateTime-Extensions has). Users land on the real docs and can switch versions via the in-page dropdown.

## After merge

Re-trigger `docfx.yaml` with `workflow_dispatch` so the root `index.html` on gh-pages regenerates from the new template:

```bash
gh workflow run docfx.yaml -R Chris-Wolfgang/D20-Dice -f version=v0.5.1
```

## Source

Verbatim copy of `repo-template/main:.github/version-picker-template.html`. Not protected — normal merge.