### PR TITLE
docfx.yaml: fix YAML syntax error from inlined here-string

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -566,29 +566,35 @@ jobs:
               $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
               $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
 
-              $html = @"
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>$title</title>
-  <meta http-equiv="refresh" content="0; url=versions/latest/">
-  <link rel="canonical" href="versions/latest/">
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-           background: #1e1e2e; color: #cdd6f4; display: flex; flex-direction: column;
-           align-items: center; justify-content: center; padding: 3rem 1rem; min-height: 100vh; margin: 0; }
-    a { color: #89b4fa; }
-  </style>
-  <script>setTimeout(function(){ window.location.replace('versions/latest/'); }, 0);</script>
-</head>
-<body>
-  <p>Redirecting to the latest documentation&hellip;</p>
-  <noscript><p><a href="versions/latest/">Continue to the latest documentation</a></p></noscript>
-</body>
-</html>
-"@
+              # Build the HTML as a string array joined with LF. Avoids a
+              # PowerShell here-string whose unindented inner lines would
+              # break the surrounding YAML literal-block scalar (they'd
+              # drop below the block's required indentation and terminate
+              # the scalar prematurely).
+              $htmlLines = @(
+                '<!DOCTYPE html>',
+                '<html lang="en">',
+                '<head>',
+                '  <meta charset="UTF-8">',
+                '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+                "  <title>$title</title>",
+                '  <meta http-equiv="refresh" content="0; url=versions/latest/">',
+                '  <link rel="canonical" href="versions/latest/">',
+                '  <style>',
+                '    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;',
+                '           background: #1e1e2e; color: #cdd6f4; display: flex; flex-direction: column;',
+                '           align-items: center; justify-content: center; padding: 3rem 1rem; min-height: 100vh; margin: 0; }',
+                '    a { color: #89b4fa; }',
+                '  </style>',
+                "  <script>setTimeout(function(){ window.location.replace('versions/latest/'); }, 0);</script>",
+                '</head>',
+                '<body>',
+                '  <p>Redirecting to the latest documentation&hellip;</p>',
+                '  <noscript><p><a href="versions/latest/">Continue to the latest documentation</a></p></noscript>',
+                '</body>',
+                '</html>'
+              )
+              $html = $htmlLines -join "`n"
               $html | Set-Content -Path "$siteDir/index.html" -Encoding utf8NoBOM
               Write-Host "Generated root index.html (meta-refresh → versions/latest/)."
 


### PR DESCRIPTION
## Summary

PR #159 introduced a PowerShell `@"..."@` here-string for the root-redirect HTML. The here-string's inner lines start at column 1, dropping below the surrounding YAML `run: |` block's required indentation. YAML parses that as the literal scalar terminating prematurely, then chokes on the `<!DOCTYPE html>` line as YAML syntax — producing:

```
Invalid workflow file: .github/workflows/docfx.yaml#L570
You have an error in your yaml syntax on line 570
```

All 8 `workflow_dispatch` runs to rebuild v0.1.0..v0.5.1 docs failed with this error.

## Fix

Replace the here-string with a string array joined by LF. Each array element is a properly-indented PowerShell expression that YAML can include in the literal scalar; the strings themselves contain just the HTML text. Produces byte-identical output.

## Protected file

`.github/workflows/docfx.yaml` — admin-bypass merge required.