### PR TITLE
Replace abandoned favicon design with canonical #156 (serif W + purple glow)

### DIFF
--- a/docfx_project/favicon.svg
+++ b/docfx_project/favicon.svg
@@ -1,7 +1,12 @@
-<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Wolfgang">
-  <rect x="0" y="0" width="32" height="32" rx="6" ry="6" fill="#7c5cf6"/>
-  <rect x="1.6" y="1.6" width="28.8" height="28.8" rx="5.4" ry="5.4" fill="#4a1e9e"/>
-  <text x="16" y="16" text-anchor="middle" dominant-baseline="central"
-        font-family="'Segoe UI Black', 'Arial Black', system-ui, sans-serif"
-        font-weight="900" font-size="20" fill="#ffffff">W</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <style>
+    .w {
+      font-family: Georgia, "Times New Roman", "DejaVu Serif", serif;
+      font-weight: 700;
+      font-size: 30px;
+      fill: #7c23bb;
+      filter: drop-shadow(0 0 2px rgba(124, 35, 187, 0.5));
+    }
+  </style>
+  <text class="w" x="16" y="26" text-anchor="middle">W</text>
 </svg>


### PR DESCRIPTION
Closes #189.

## Summary

Replaces `docfx_project/favicon.svg` with the canonical design locked in by In-memory-Logger #156. The current content is the abandoned `#151` design (purple rounded tile + white sans-serif W) that the initial fan-out shipped before the design was finalized.

## Canonical SVG (byte-for-byte from In-memory-Logger #156)

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
  <style>
    .w {
      font-family: Georgia, "Times New Roman", "DejaVu Serif", serif;
      font-weight: 700;
      font-size: 30px;
      fill: #7c23bb;
      filter: drop-shadow(0 0 2px rgba(124, 35, 187, 0.5));
    }
  </style>
  <text class="w" x="16" y="26" text-anchor="middle">W</text>
</svg>
```

## Why this design

- Serif `<text>` glyph (Georgia / DejaVu Serif) matches the navbar logo's serif W aesthetic — geometric path designs (chevron, polyline) drifted off-brand.
- Brand purple `#7c23bb` with `drop-shadow(0 0 2px rgba(124,35,187,0.5))` makes the W read as vivid purple against both light and dark browser chrome — no `prefers-color-scheme` flip needed.
- Transparent background — the dark purple tile in the previous design made the favicon look like a UI chip rather than a brand mark.

Full rationale and 5-PR iteration trail in #189.

## After merge

Re-dispatch `docfx.yaml` so `versions/latest/favicon.svg` redeploys. Hard-refresh (Ctrl+Shift+R) to bust Fastly's 10-minute `max-age=600` favicon cache.

## Fleet impact

Identical fix is needed in every other repo that received the original fan-out — those tier-1 issues will be worked individually per the bottom-up sweep.