### PR TITLE
Prep CHANGELOG for v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.6.0] - 2026-06-19
+
+`Dice` is now a collection of individual `Die`, enabling heterogeneous
+rolls such as `2d6+1d4+3`. See #48.
+
+### Added
+
 - **#48** — `Die` type representing a single die (`SideCount`, `MinValue`,
   `MaxValue`, `Roll`, value equality) and its `IDie` interface. Construct a
   die directly from its side count, e.g. `new Die(20)`.
@@ -22,11 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **#48** — `Dice.TryParse` now parses heterogeneous notation
   (e.g. `2d6+1d4+3`) and ignores whitespace. `Dice.ToString` groups dice
-  by side count in descending order.
+  by side count in the order each side count first appears, with the flat
+  modifier always last.
 - **#48** — `Dice` equality now compares the multiset of dice plus the
   modifier (order-independent); `Dice.Modifier` is now settable.
-
-### Deprecated
 
 ### Removed
 
@@ -35,10 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single `SideCount` on `Dice` is no longer meaningful.
 - **#48 (breaking)** — `Dice` no longer implements `IEqualityComparer<Dice>`.
 - **#48 (breaking)** — `IDice.SideCount` has been removed from the interface.
-
-### Fixed
-
-### Security
 
 ## [0.5.1] - 2026-05-31
 


### PR DESCRIPTION
Release-prep for **v0.6.0**.

`main` is already at version `0.6.0` (bumped in #195, which delivered the #48 `Dice`-as-collection-of-`Die` redesign). This PR finalizes the CHANGELOG so the release can be cut.

## Changes
- Move the `[Unreleased]` entries into a dated `## [0.6.0] - 2026-06-19` section and reset `[Unreleased]` to an empty template (Keep a Changelog convention).
- Fix a stale note carried over before the #195 review fixes: `Dice.ToString` groups dice in **first-appearance order with the modifier last**, not "descending order".

No source or csproj changes — version is already `0.6.0`.

## After merge (deploy)
This repo's `release.yaml` triggers on `release: published`, not tag push. To ship:

```
gh release create v0.6.0 --target main --title "v0.6.0" --notes-file <0.6.0 changelog section>
```

That tags **and** publishes the Release object, which runs the release pipeline (docs build gate + NuGet push). I can do this once this PR merges if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
