### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependabot bump: dotnet-dependencies group (5 packages).
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 ## [0.6.0] - 2026-06-19
 
 `Dice` is now a collection of individual `Die`, enabling heterogeneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.6.1] - 2026-07-06
+
+### Changed
+
+- Dependabot bump: dotnet-dependencies group (5 packages).
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.6.0] - 2026-06-19
 
 `Dice` is now a collection of individual `Die`, enabling heterogeneous
@@ -102,3 +120,7 @@ runtime behavior change vs v0.5.0.
   add a binding redirect to upgrade to v0.5.1 from any earlier v0.x.
   See DateTime-Extensions v1.3.1 post-mortem for what happens when this
   pin is dropped and SDK-derived AssemblyVersion changes per release.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/Chris-Wolfgang/D20-Dice/releases/tag/v0.6.0

--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-	  <Version>0.6.0</Version>
+	  <Version>0.6.1</Version>
 	  <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	       do not need to recompile / add binding redirects on every minor/patch
 	       bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Release prep — v0.6.1

Bump `<Version>` from `0.6.0` to `0.6.1`, promote `[Unreleased]` in CHANGELOG.md.

### Change

```
### Changed
- Dependabot bump: dotnet-dependencies group (5 packages).
```

## After merge

Create the release: `gh release create v0.6.1 --target main --title "v0.6.1" --generate-notes` (or via UI). The release.yaml workflow fires on `release: published` and handles the NuGet publish.