### PR TITLE
Add AverageRoundedUp/AverageRoundedDown extensions (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `AverageRoundedUp()` and `AverageRoundedDown()` extension methods on `IDie` and `IDice`,
+  returning the average roll rounded to a whole number. See #49.
+
 ### Changed
 
 ### Deprecated

--- a/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
+++ b/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
@@ -1,0 +1,107 @@
+namespace Wolfgang.D20;
+
+/// <summary>
+/// Extension methods that compute the average roll of a die or collection of dice, rounded to a whole number.
+/// </summary>
+/// <remarks>
+/// The average roll is the midpoint of the possible results, <c>(MinValue + MaxValue) / 2</c>, which is always
+/// a whole number or a half. These methods round that midpoint to an <see cref="int"/>, which is convenient for
+/// tabletop rules that call for average damage rounded a particular way &#8212; for example, half damage on a
+/// successful save is conventionally rounded down.
+/// </remarks>
+public static class AverageRollExtensions
+{
+
+    /// <summary>
+    /// Returns the average roll of the die, rounded up to the nearest whole number.
+    /// </summary>
+    /// <param name="die">The die to average.</param>
+    /// <returns>
+    /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded up.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    public static int AverageRoundedUp(this IDie die)
+    {
+        if (die is null)
+        {
+            throw new ArgumentNullException(nameof(die));
+        }
+
+        return (int)Math.Ceiling(Average(die.MinValue, die.MaxValue));
+    }
+
+
+
+    /// <summary>
+    /// Returns the average roll of the dice, including the modifier, rounded up to the nearest whole number.
+    /// </summary>
+    /// <param name="dice">The dice to average.</param>
+    /// <returns>
+    /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded up.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    public static int AverageRoundedUp(this IDice dice)
+    {
+        if (dice is null)
+        {
+            throw new ArgumentNullException(nameof(dice));
+        }
+
+        return (int)Math.Ceiling(Average(dice.MinValue, dice.MaxValue));
+    }
+
+
+
+    /// <summary>
+    /// Returns the average roll of the die, rounded down to the nearest whole number.
+    /// </summary>
+    /// <param name="die">The die to average.</param>
+    /// <returns>
+    /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded down.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    public static int AverageRoundedDown(this IDie die)
+    {
+        if (die is null)
+        {
+            throw new ArgumentNullException(nameof(die));
+        }
+
+        return (int)Math.Floor(Average(die.MinValue, die.MaxValue));
+    }
+
+
+
+    /// <summary>
+    /// Returns the average roll of the dice, including the modifier, rounded down to the nearest whole number.
+    /// </summary>
+    /// <param name="dice">The dice to average.</param>
+    /// <returns>
+    /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded down.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    public static int AverageRoundedDown(this IDice dice)
+    {
+        if (dice is null)
+        {
+            throw new ArgumentNullException(nameof(dice));
+        }
+
+        return (int)Math.Floor(Average(dice.MinValue, dice.MaxValue));
+    }
+
+
+
+    /// <summary>
+    /// Computes the midpoint of the inclusive range [<paramref name="minValue"/>, <paramref name="maxValue"/>].
+    /// </summary>
+    /// <param name="minValue">The minimum value that can be rolled.</param>
+    /// <param name="maxValue">The maximum value that can be rolled.</param>
+    /// <returns>The average of the two bounds, always a whole number or a half.</returns>
+    private static decimal Average(int minValue, int maxValue)
+    {
+        // Promote to decimal before adding so the sum cannot overflow int and the .0 / .5 result stays exact.
+        return ((decimal)minValue + maxValue) / 2m;
+    }
+
+}

--- a/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using Xunit;
+// ReSharper disable RedundantArgumentDefaultValue
+
+namespace Wolfgang.D20.Tests.Unit;
+
+public class AverageRollExtensionsTests
+{
+
+    // ----- IDie -----
+
+    [Theory]
+    [InlineData(6, 4)]    // avg 3.5 -> 4
+    [InlineData(20, 11)]  // avg 10.5 -> 11
+    [InlineData(4, 3)]    // avg 2.5 -> 3
+    [InlineData(3, 2)]    // avg 2.0 -> 2 (whole number is unaffected)
+    [InlineData(2, 2)]    // avg 1.5 -> 2
+    public void Die_AverageRoundedUp_rounds_the_midpoint_up(int sideCount, int expected)
+    {
+        // Arrange
+        var die = new Die(sideCount);
+
+        // Act
+        var actual = die.AverageRoundedUp();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+
+
+    [Theory]
+    [InlineData(6, 3)]    // avg 3.5 -> 3
+    [InlineData(20, 10)]  // avg 10.5 -> 10
+    [InlineData(4, 2)]    // avg 2.5 -> 2
+    [InlineData(3, 2)]    // avg 2.0 -> 2 (whole number is unaffected)
+    [InlineData(2, 1)]    // avg 1.5 -> 1
+    public void Die_AverageRoundedDown_rounds_the_midpoint_down(int sideCount, int expected)
+    {
+        // Arrange
+        var die = new Die(sideCount);
+
+        // Act
+        var actual = die.AverageRoundedDown();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+
+
+    [Fact]
+    public void Die_AverageRoundedUp_null_throws_ArgumentNullException()
+    {
+        // Arrange
+        IDie die = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => die.AverageRoundedUp());
+    }
+
+
+
+    [Fact]
+    public void Die_AverageRoundedDown_null_throws_ArgumentNullException()
+    {
+        // Arrange
+        IDie die = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => die.AverageRoundedDown());
+    }
+
+
+
+    // ----- IDice -----
+
+    [Theory]
+    [InlineData(2, 6, 0, 7)]    // 2d6   min 2  max 12  avg 7.0  -> 7
+    [InlineData(2, 6, 1, 8)]    // 2d6+1 min 3  max 13  avg 8.0  -> 8
+    [InlineData(1, 6, 0, 4)]    // 1d6   min 1  max 6   avg 3.5  -> 4
+    [InlineData(3, 8, 0, 14)]   // 3d8   min 3  max 24  avg 13.5 -> 14
+    [InlineData(1, 4, -1, 2)]   // 1d4-1 min 0  max 3   avg 1.5  -> 2
+    public void Dice_AverageRoundedUp_rounds_the_midpoint_up(int dieCount, int sideCount, int modifier, int expected)
+    {
+        // Arrange
+        var dice = new Dice(dieCount, sideCount, modifier);
+
+        // Act
+        var actual = dice.AverageRoundedUp();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+
+
+    [Theory]
+    [InlineData(2, 6, 0, 7)]    // 2d6   avg 7.0  -> 7
+    [InlineData(2, 6, 1, 8)]    // 2d6+1 avg 8.0  -> 8
+    [InlineData(1, 6, 0, 3)]    // 1d6   avg 3.5  -> 3
+    [InlineData(3, 8, 0, 13)]   // 3d8   avg 13.5 -> 13
+    [InlineData(1, 4, -1, 1)]   // 1d4-1 avg 1.5  -> 1
+    public void Dice_AverageRoundedDown_rounds_the_midpoint_down(int dieCount, int sideCount, int modifier, int expected)
+    {
+        // Arrange
+        var dice = new Dice(dieCount, sideCount, modifier);
+
+        // Act
+        var actual = dice.AverageRoundedDown();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+
+
+    [Fact]
+    public void Dice_AverageRoundedUp_accounts_for_heterogeneous_dice()
+    {
+        // Arrange - 1d6 + 1d4: min 2, max 10, avg 6.0
+        var dice = new Dice(new List<Die> { new(6), new(4) });
+
+        // Act & Assert
+        Assert.Equal(6, dice.AverageRoundedUp());
+    }
+
+
+
+    [Fact]
+    public void Dice_AverageRoundedUp_null_throws_ArgumentNullException()
+    {
+        // Arrange
+        IDice dice = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => dice.AverageRoundedUp());
+    }
+
+
+
+    [Fact]
+    public void Dice_AverageRoundedDown_null_throws_ArgumentNullException()
+    {
+        // Arrange
+        IDice dice = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => dice.AverageRoundedDown());
+    }
+
+}


### PR DESCRIPTION
Closes #49.

## What

Adds `IDie` / `IDice` extension methods that return the **average roll rounded to a whole number**:

- `AverageRoundedUp()` — midpoint rounded up
- `AverageRoundedDown()` — midpoint rounded down

Both return `int`, on both `IDie` and `IDice`. Useful for tabletop rules that call for average damage rounded a particular way (e.g. half damage on a save is conventionally rounded down).

## Design notes

- Per discussion on #49, **no public `AverageRoll` property / `decimal` is exposed** — the average is computed internally.
- Average = `(MinValue + MaxValue) / 2`, which is always a whole number or `.5`. The sum is promoted to `decimal` before dividing so it can't overflow `int` and the `.0`/`.5` result stays exact.
- The halving helper floated in the issue is intentionally left out; these two rounding methods cover the stated use case.

## Tests

25 new tests in `AverageRollExtensionsTests.cs` covering up/down rounding for `Die` and `Dice` (including modifiers, a negative modifier, and heterogeneous dice), whole-number cases, and null-argument guards. All green locally on net10.0; CI runs the full TFM matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)