### PR TITLE
Format dice notation with invariant culture (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#177** — `Die.ToString()` and `Dice.ToString()` now format numbers with the invariant
+  culture, so dice notation always uses ASCII digits and an ASCII `-` sign and round-trips
+  through `Dice.TryParse` regardless of the current thread culture.
+
 ### Security
 
 ## [0.6.1] - 2026-07-06

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -296,17 +297,24 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
             {
                 builder.Append('+');
             }
-            builder.Append(group.Count()).Append('d').Append(group.Key);
+            // Format counts with the invariant culture so the notation always uses ASCII digits and
+            // round-trips through TryParse regardless of the current thread culture.
+            builder
+                .Append(group.Count().ToString(CultureInfo.InvariantCulture))
+                .Append('d')
+                .Append(group.Key.ToString(CultureInfo.InvariantCulture));
             first = false;
         }
 
         switch (Modifier)
         {
             case > 0:
-                builder.Append('+').Append(Modifier);
+                // The invariant '+' is a literal; only the magnitude needs invariant formatting.
+                builder.Append('+').Append(Modifier.ToString(CultureInfo.InvariantCulture));
                 break;
             case < 0:
-                builder.Append(Modifier);
+                // Invariant formatting emits the ASCII '-' sign, matching what TryParse accepts.
+                builder.Append(Modifier.ToString(CultureInfo.InvariantCulture));
                 break;
         }
 

--- a/src/Wolfgang.D20.Dice/Die.cs
+++ b/src/Wolfgang.D20.Dice/Die.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Wolfgang.D20;
 
 /// <summary>
@@ -76,7 +78,9 @@ public sealed class Die : IDie, IEquatable<Die>
     /// <returns>The die in standard <c>dY</c> notation.</returns>
     public override string ToString()
     {
-        return $"d{SideCount}";
+        // Format the side count with the invariant culture so the notation always uses ASCII digits and
+        // round-trips through TryParse regardless of the current thread culture.
+        return "d" + SideCount.ToString(CultureInfo.InvariantCulture);
     }
 
 

--- a/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
@@ -9,20 +9,24 @@ public class GlobalizationTests
 {
 
     /// <summary>
-    /// Runs <paramref name="action"/> with <see cref="Thread.CurrentCulture"/> set to
-    /// <paramref name="culture"/>, restoring the original culture afterwards.
+    /// Runs <paramref name="action"/> with both <see cref="Thread.CurrentCulture"/> and
+    /// <see cref="Thread.CurrentUICulture"/> set to <paramref name="culture"/>, restoring both afterwards.
     /// </summary>
     private static void WithCulture(CultureInfo culture, Action action)
     {
-        var original = Thread.CurrentThread.CurrentCulture;
-        Thread.CurrentThread.CurrentCulture = culture;
+        var thread = Thread.CurrentThread;
+        var originalCulture = thread.CurrentCulture;
+        var originalUICulture = thread.CurrentUICulture;
+        thread.CurrentCulture = culture;
+        thread.CurrentUICulture = culture;
         try
         {
             action();
         }
         finally
         {
-            Thread.CurrentThread.CurrentCulture = original;
+            thread.CurrentCulture = originalCulture;
+            thread.CurrentUICulture = originalUICulture;
         }
     }
 
@@ -32,6 +36,12 @@ public class GlobalizationTests
     // dice notation (native digits, non-ASCII signs, RTL scripts).
     public static IEnumerable<object[]> Cultures()
     {
+        // Cultures called out in the #177 acceptance criteria.
+        yield return new object[] { "en-US" };
+        yield return new object[] { "tr-TR" };
+        yield return new object[] { "zh-CN" };
+        yield return new object[] { "ja-JP" };
+        // Additional cultures whose number formatting stresses digits / signs / RTL scripts.
         yield return new object[] { "ar-SA" };
         yield return new object[] { "fa-IR" };
         yield return new object[] { "fi-FI" };

--- a/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+namespace Wolfgang.D20.Tests.Unit;
+
+public class GlobalizationTests
+{
+
+    /// <summary>
+    /// Runs <paramref name="action"/> with <see cref="Thread.CurrentCulture"/> set to
+    /// <paramref name="culture"/>, restoring the original culture afterwards.
+    /// </summary>
+    private static void WithCulture(CultureInfo culture, Action action)
+    {
+        var original = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
+
+
+
+    // Cultures whose number formatting differs from the invariant culture in ways that could leak into
+    // dice notation (native digits, non-ASCII signs, RTL scripts).
+    public static IEnumerable<object[]> Cultures()
+    {
+        yield return new object[] { "ar-SA" };
+        yield return new object[] { "fa-IR" };
+        yield return new object[] { "fi-FI" };
+        yield return new object[] { "de-DE" };
+        yield return new object[] { "th-TH" };
+        yield return new object[] { "hi-IN" };
+    }
+
+
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void Die_ToString_is_culture_invariant(string cultureName)
+    {
+        WithCulture(new CultureInfo(cultureName), () =>
+        {
+            // Arrange & Act
+            var actual = new Die(20).ToString();
+
+            // Assert
+            Assert.Equal("d20", actual);
+        });
+    }
+
+
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void Dice_ToString_is_culture_invariant(string cultureName)
+    {
+        WithCulture(new CultureInfo(cultureName), () =>
+        {
+            // Arrange & Act - includes a negative modifier, the culture-sensitive case.
+            var actual = new Dice(2, 6, -3).ToString();
+
+            // Assert
+            Assert.Equal("2d6-3", actual);
+        });
+    }
+
+
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void Dice_ToString_round_trips_through_TryParse_under_any_culture(string cultureName)
+    {
+        WithCulture(new CultureInfo(cultureName), () =>
+        {
+            // Arrange
+            var original = new Dice(2, 6, -3);
+
+            // Act
+            var parsed = Dice.TryParse(original.ToString());
+
+            // Assert
+            Assert.True(parsed.Succeeded, parsed.ErrorMessage);
+            Assert.Equal(original, parsed.Value);
+        });
+    }
+
+
+
+    [Fact]
+    public void Dice_ToString_ignores_a_hostile_current_culture_negative_sign()
+    {
+        // Arrange - a culture whose NegativeSign is a non-ASCII sentinel. int.ToString always emits ASCII
+        // digits, so the negative sign is the axis that a current-culture leak would corrupt.
+        var hostile = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        hostile.NumberFormat.NegativeSign = "−"; // MINUS SIGN, not ASCII '-'
+
+        WithCulture(hostile, () =>
+        {
+            // Act
+            var actual = new Dice(1, 6, -1).ToString();
+
+            // Assert - the fix formats invariantly, so the ASCII '-' is used regardless of the culture.
+            Assert.Equal("1d6-1", actual);
+        });
+    }
+
+}


### PR DESCRIPTION
Closes #177.

## Problem

`Die.ToString()` (string interpolation) and `Dice.ToString()` (`StringBuilder.Append(int)`) formatted numbers with the **current thread culture**. `Dice.TryParse` parses with `InvariantCulture`, so the output and input sides disagreed under non-invariant cultures.

.NET's `int.ToString` emits ASCII digits regardless of culture, so the practical failure axis is the **negative sign**: under a culture whose `NegativeSign` is not ASCII `-` (some cultures use U+2212), `new Dice(1, 6, -1).ToString()` produced notation that would not round-trip through `TryParse`.

## Fix

Format all counts and the modifier with `CultureInfo.InvariantCulture` in both `ToString` overrides, so notation always uses ASCII digits and an ASCII sign.

## Tests

New `GlobalizationTests`:
- Culture matrix (`ar-SA`, `fa-IR`, `fi-FI`, `de-DE`, `th-TH`, `hi-IN`): `Die`/`Dice` `ToString` equal the invariant string, and `Dice.ToString()` round-trips through `TryParse`.
- A deterministic test that installs a culture with a non-ASCII `NegativeSign` sentinel and asserts the ASCII `-` is still emitted — this fails without the fix.

All 168 tests green locally on net10.0; CI runs the full TFM matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)