### PR TITLE
Make Dice.Roll allocation-free on the hot path (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **#179** — `Dice.Roll()` and `Dice.MaxValue` now iterate the underlying dice list directly
+  instead of via LINQ `Sum`, eliminating the boxed-enumerator heap allocation so the roll hot
+  path is allocation-free. Added allocation guard tests (net6.0+).
+
 ### Deprecated
 
 ### Removed

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -138,10 +138,16 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     {
         get
         {
-            // Enumerable.Sum performs checked addition and throws OverflowException on overflow.
             checked
             {
-                return _dice.Sum(die => die.SideCount) + Modifier;
+                // foreach over the concrete List<Die> uses its struct enumerator and allocates nothing,
+                // unlike Enumerable.Sum which boxes the enumerator. The checked context guards overflow.
+                var sum = Modifier;
+                foreach (var die in _dice)
+                {
+                    sum += die.SideCount;
+                }
+                return sum;
             }
         }
     }
@@ -157,10 +163,17 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// </returns>
     public int Roll()
     {
-        // Enumerable.Sum performs checked addition and throws OverflowException on overflow.
         checked
         {
-            return _dice.Sum(die => die.Roll()) + Modifier;
+            // Iterate the List<Die> directly rather than via Enumerable.Sum: a foreach over the concrete
+            // list uses its struct enumerator, so this hot path allocates nothing (LINQ would box the
+            // enumerator on the heap). The checked context still guards the running total against overflow.
+            var total = Modifier;
+            foreach (var die in _dice)
+            {
+                total += die.Roll();
+            }
+            return total;
         }
     }
 

--- a/tests/Wolfgang.D20.Dice.Tests/AllocationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/AllocationTests.cs
@@ -1,0 +1,83 @@
+#if NET6_0_OR_GREATER
+using Xunit;
+
+namespace Wolfgang.D20.Tests.Unit;
+
+/// <summary>
+/// Verifies that the roll hot paths allocate nothing on the managed heap. Guarded to net6.0+, where
+/// <see cref="GC.GetAllocatedBytesForCurrentThread"/> is available and JIT behaviour is stable.
+/// </summary>
+public class AllocationTests
+{
+
+    private const int Iterations = 1000;
+
+
+
+    /// <summary>
+    /// Measures the bytes allocated on the current thread while running <paramref name="action"/>
+    /// <see cref="Iterations"/> times, after a warm-up pass that lets the JIT compile the code under test.
+    /// </summary>
+    private static long MeasureAllocations(Action action)
+    {
+        // Warm up so method JIT / tiered compilation happens before measurement rather than during it.
+        for (var i = 0; i < 100; i++)
+        {
+            action();
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < Iterations; i++)
+        {
+            action();
+        }
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+
+
+    [Fact]
+    public void Die_Roll_allocates_nothing()
+    {
+        // Arrange
+        var die = new Die(20);
+
+        // Act
+        var allocated = MeasureAllocations(() => die.Roll());
+
+        // Assert
+        Assert.Equal(0, allocated);
+    }
+
+
+
+    [Fact]
+    public void Dice_Roll_allocates_nothing()
+    {
+        // Arrange - a heterogeneous pool with a modifier exercises the full Roll path.
+        var dice = new Dice(new[] { new Die(6), new Die(6), new Die(4) }, modifier: 2);
+
+        // Act
+        var allocated = MeasureAllocations(() => dice.Roll());
+
+        // Assert
+        Assert.Equal(0, allocated);
+    }
+
+
+
+    [Fact]
+    public void Dice_MaxValue_allocates_nothing()
+    {
+        // Arrange
+        var dice = new Dice(new[] { new Die(6), new Die(6), new Die(4) }, modifier: 2);
+
+        // Act
+        var allocated = MeasureAllocations(() => _ = dice.MaxValue);
+
+        // Assert
+        Assert.Equal(0, allocated);
+    }
+
+}
+#endif


### PR DESCRIPTION
Closes #179.

## Problem

`Dice.Roll()` and `Dice.MaxValue` computed their totals with `Enumerable.Sum` over the `List<Die>` field. Calling a LINQ operator on the list through `IEnumerable<Die>` boxes the list's struct enumerator on the heap — one allocation per call, on the roll hot path.

## Fix

Replace the LINQ `Sum` calls with a direct `foreach` over the concrete `List<Die>`, which uses the list's struct enumerator (no boxing). The `checked` context is preserved so overflow behavior is unchanged.

## Tests

New `AllocationTests` (guarded to net6.0+, where `GC.GetAllocatedBytesForCurrentThread` is available and JIT behavior is stable): assert `Die.Roll`, `Dice.Roll`, and `Dice.MaxValue` each allocate **0 bytes** across 1000 iterations after warm-up.

All tests green locally on net10.0; CI runs the full TFM matrix (allocation tests compile only on net6.0+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)