### PR TITLE
Add property-based tests with CsCheck (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **#162** — Internal: added property-based tests (CsCheck, net8.0+) asserting roll results stay
+  within bounds and that `Dice.ToString` round-trips through `Dice.TryParse`.
+
 ### Deprecated
 
 ### Removed

--- a/tests/Wolfgang.D20.Dice.Tests/PropertyTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/PropertyTests.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using CsCheck;
+using Xunit;
+
+namespace Wolfgang.D20.Tests.Unit;
+
+/// <summary>
+/// Property-based tests (CsCheck) that assert invariants hold across a wide range of randomly generated
+/// dice. Guarded to net8.0+, the target framework CsCheck 4.x supports; the framework-independent behaviour
+/// is exercised on every other TFM by the example-based tests.
+/// </summary>
+public class PropertyTests
+{
+
+    // A single die with a side count anywhere in the valid range.
+    private static readonly Gen<Die> GenDie = Gen.Int[2, 1000].Select(sideCount => new Die(sideCount));
+
+
+
+    // A pool of 1-8 dice with a modifier in a range that cannot overflow when summed.
+    private static readonly Gen<Dice> GenDice =
+        Gen.Select(GenDie.List[1, 8], Gen.Int[-100, 100], (dice, modifier) => new Dice(dice, modifier));
+
+
+
+    [Fact]
+    public void Die_Roll_is_always_within_its_bounds()
+    {
+        GenDie.Sample(die =>
+        {
+            var roll = die.Roll();
+            return roll >= die.MinValue && roll <= die.MaxValue;
+        });
+    }
+
+
+
+    [Fact]
+    public void Dice_Roll_is_always_within_its_bounds()
+    {
+        GenDice.Sample(dice =>
+        {
+            var roll = dice.Roll();
+            return roll >= dice.MinValue && roll <= dice.MaxValue;
+        });
+    }
+
+
+
+    [Fact]
+    public void Dice_MinValue_never_exceeds_MaxValue()
+    {
+        GenDice.Sample(dice => dice.MinValue <= dice.MaxValue);
+    }
+
+
+
+    [Fact]
+    public void Dice_ToString_round_trips_through_TryParse()
+    {
+        GenDice.Sample(dice =>
+        {
+            var parsed = Dice.TryParse(dice.ToString());
+            return parsed.Succeeded && dice.Equals(parsed.Value);
+        });
+    }
+
+}
+#endif

--- a/tests/Wolfgang.D20.Dice.Tests/Wolfgang.D20.Dice.Tests.Unit.csproj
+++ b/tests/Wolfgang.D20.Dice.Tests/Wolfgang.D20.Dice.Tests.Unit.csproj
@@ -91,6 +91,8 @@
   	<PackageReference Include="xunit" Version="2.9.3" />
   	<PackageReference Include="xunit.assert" Version="2.9.3" />
   	<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
+  	<!-- Property-based tests (PropertyTests.cs) are guarded to net8.0+; CsCheck 4.x targets net8.0. -->
+  	<PackageReference Include="CsCheck" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of #162 (does **not** fully close it — see Scope below).

## What

Adds [CsCheck](https://github.com/AnthonyLloyd/CsCheck) property-based tests asserting core invariants across a wide range of randomly generated dice:

- `Die.Roll()` always falls within `[MinValue, MaxValue]`
- `Dice.Roll()` always falls within `[MinValue, MaxValue]`
- `Dice.MinValue` never exceeds `Dice.MaxValue`
- `Dice.ToString()` round-trips through `Dice.TryParse()`

## Scope

Issue #162 asks for **continuous / scheduled fuzz running (CI-time hours)**. This PR delivers the property-test foundation but not the scheduled long-run harness (weekly workflow, replay artifacts, auto-issue filing), so #162 stays open for that follow-up.

## Framework scoping

CsCheck 4.x targets **net8.0**, so the package is referenced only in the net8.0/net9.0/net10.0 group and `PropertyTests.cs` is guarded with `#if NET8_0_OR_GREATER`. The same behaviors are exercised on every other TFM by the example-based tests.

## Verification

187 tests green locally on net10.0 after merging current `main`; CI runs the full TFM matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)