### PR TITLE
Enable SDK PackageValidation for API/ABI compat (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **#169** — Internal: enabled SDK PackageValidation against the last released version
+  (`PackageValidationBaselineVersion`), so an accidental breaking API/ABI change fails `dotnet pack`.
+
 ### Deprecated
 
 ### Removed

--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -6,6 +6,10 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 	  <Version>0.6.1</Version>
+	  <!-- API/ABI compatibility gate (#169): validate the packed API surface against the last released
+	       version so an accidental breaking change fails the pack. Bump the baseline on each release. -->
+	  <EnablePackageValidation>true</EnablePackageValidation>
+	  <PackageValidationBaselineVersion>0.6.1</PackageValidationBaselineVersion>
 	  <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	       do not need to recompile / add binding redirects on every minor/patch
 	       bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
Closes #169.

## What

Enables the .NET SDK's built-in **PackageValidation** on the library project, using the last released version as the baseline:

```xml
<EnablePackageValidation>true</EnablePackageValidation>
<PackageValidationBaselineVersion>0.6.1</PackageValidationBaselineVersion>
```

At `dotnet pack` time, the packed API surface is compared against the baseline package pulled from NuGet. An accidental breaking change (removed or changed public member, ABI break across target frameworks) fails the pack with a `CP0xxx` error — giving the same guarantee as `Microsoft.DotNet.ApiCompat` without adding a separate tool or workflow.

## Why this approach

- No new CI workflow (so no protected-file churn) — the check runs wherever `dotnet pack` runs, including `release.yaml`.
- Zero extra dependency: PackageValidation ships in the SDK.

## Maintenance

Bump `PackageValidationBaselineVersion` to the newly released version as part of each release (a natural companion to the existing `<Version>` bump).

## Verification

`dotnet pack -c Release` locally: package builds successfully, PackageValidation runs against `0.6.1` with no compatibility findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)