### PR TITLE
ci(pr): add ReSharper InspectCode job (canonical)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -239,6 +239,81 @@ jobs:
             echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
+  # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
 
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -246,17 +246,25 @@ jobs:
   # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
   # annotations). `error`-severity findings fail the job; `warning`-severity
   # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
-  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # filter). Optionally tune the noise floor with a *.DotSettings file at the
+  # repo root (none is present by default).
   # ============================================================================
   inspectcode:
     name: "ReSharper InspectCode"
-    runs-on: ubuntu-latest
+    # windows-latest so every target framework (incl. net462 / net48-only example
+    # projects) builds natively — an unfiltered `dotnet build -c Release` and
+    # whole-solution analysis both fail on ubuntu, which lacks the .NET Framework
+    # reference assemblies. The bash steps below run under Git Bash via defaults.
+    runs-on: windows-latest
     needs: detect-projects
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     timeout-minutes: 20
     permissions:
       contents: read
       security-events: write   # required for upload-sarif
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Adds the canonical **ReSharper InspectCode** CI job (repo-template #427) to `pr.yaml`.

**Additive** — only the `inspectcode:` job is inserted (after `detect-projects`, before the test stages). No existing job modified or removed (avoids the full-file-overwrite regression from Etl-DbClient #224).

- `runs-on: ubuntu-latest`; `needs: detect-projects`, guarded by `has-projects == 'true'`.
- Build Release → `jb inspectcode` → SARIF → Code Scanning. Gate fails only on `level=error`.

Proven green on AuditTrail, ETL-FixedWidth, System.Mail-Extensions. Protected file → merge via `merge-fleet-prs.ps1 -Branch chore/add-inspectcode`.