### PR TITLE
InspectCode cleanup (B): remove redundant usings/cast in tests

### DIFF
--- a/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 

--- a/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 
@@ -143,7 +140,7 @@ public class DiceTests
     [Fact]
     public void Constructed_from_null_sequence_throws_ArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new Dice((IEnumerable<Die>)null!));
+        Assert.Throws<ArgumentNullException>(() => new Dice(null!));
     }
 
 

--- a/tests/Wolfgang.D20.Dice.Tests/DieTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/DieTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 

--- a/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace Wolfgang.D20.Tests.Unit;


### PR DESCRIPTION
Second InspectCode cleanup (A merged as #215). **Real fixes only** — no behavior change.

## Fixes
- **RedundantUsingDirective** — remove `using System;` / `System.Collections.Generic` / `System.Linq` / `System.Threading` where ImplicitUsings already provides them (DiceTests, DieTests, GlobalizationTests, AverageRollExtensionsTests).
- **RedundantCast** — drop `(IEnumerable<Die>)` on the null-sequence constructor test (`new Dice(null!)` binds unambiguously).

## Left as-is (false positives / domain noise, per review)
- `xUnit2017` ×4 — the `dice.Contains(...)` calls test `Dice.Contains` (the SUT).
- `CollectionNeverUpdated/Queried.Local` ×10 — fire only because `Dice` is an ICollection; tests legitimately don't mutate it.
- `RedundantArgumentDefaultValue` / `RedundantExplicitArrayCreation` — intentional explicit `new Die(6)`; `Die?[]` needed for the null element.

187 tests pass on net10.0; net462 builds clean. Stacked: C (benchmarks/examples) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)