### PR TITLE
InspectCode cleanup (C): remove redundant usings in benchmarks/examples

### DIFF
--- a/benchmarks/Wolfgang.D20.Dice.Benchmarks/DiceBenchmarks.cs
+++ b/benchmarks/Wolfgang.D20.Dice.Benchmarks/DiceBenchmarks.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using Wolfgang.D20;
 
 namespace Wolfgang.D20.Benchmarks;
 

--- a/examples/Net4.8/Example1-Console/Properties/AssemblyInfo.cs
+++ b/examples/Net4.8/Example1-Console/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
Third InspectCode cleanup (after A #215 merged, B #216). **Real fixes only**, no behavior change.

## Fixes
- **DiceBenchmarks.cs** — drop `using Wolfgang.D20;` (the file's `Wolfgang.D20.Benchmarks` namespace already sees the parent).
- **Net4.8 example AssemblyInfo.cs** — drop the unused `using System.Runtime.CompilerServices;`.

## Left as-is (out of scope per review)
- `RedundantArgumentDefaultValue` on `new Dice(1, 6)` etc. — explicit defaults are the repo convention (suppressed file-wide in tests).
- `AssignNullToNotNullAttribute` ×3 in the example — `Console.ReadLine()` → `int.Parse` in Nullable-disabled demo code; guarding it is a logic change to a deliberately-minimal example, not a cleanup.

Benchmarks (net8.0) and the net4.8 example both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)