### PR TITLE
Gate Stryker on a 90% mutation-score threshold (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PackageValidation, baselined against the last release (`PackageValidationBaselineVersion`), so an
   accidental breaking change fails `dotnet pack` (and therefore the release). Intentional breaks can
   be waived with an `ApiCompatSuppressionFile`.
-- **#168** — Internal: Stryker mutation testing now gates on an 85% break threshold, so a change
-  that drops the mutation score below 85% fails the run (current score ~91%).
+- **#168** — Internal: the Stryker mutation-testing run now enforces a 90% break threshold — a
+  change that drops the mutation score below 90% fails the run. The run is triggered manually and
+  weekly (not per-PR, since mutation runs are slow).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PackageValidation, baselined against the last release (`PackageValidationBaselineVersion`), so an
   accidental breaking change fails `dotnet pack` (and therefore the release). Intentional breaks can
   be waived with an `ApiCompatSuppressionFile`.
+- **#168** — Internal: Stryker mutation testing now gates on an 85% break threshold, so a change
+  that drops the mutation score below 85% fails the run (current score ~91%).
 
 ### Deprecated
 

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -12,8 +12,8 @@
     ],
     "thresholds": {
       "high": 90,
-      "low": 85,
-      "break": 85
+      "low": 90,
+      "break": 90
     }
   }
 }

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -12,8 +12,8 @@
     ],
     "thresholds": {
       "high": 90,
-      "low": 75,
-      "break": 0
+      "low": 85,
+      "break": 85
     }
   }
 }


### PR DESCRIPTION
Closes #168.

## What

Turns the existing Stryker mutation-testing workflow into a **release-gate quality bar** by setting a break threshold (was `0` = disabled):

```jsonc
"thresholds": { "high": 90, "low": 90, "break": 90 }
```

A change that drops the mutation score below **90%** now fails the run.

## Verification

Ran Stryker locally against this branch twice — both clear the gate:

| Run | Killed | Survived | Timeout | Score |
|----|-------|---------|--------|------|
| 1 | 141 | 14 | 3 | **91.14%** |
| 2 | 141 | 13 | 4 | **91.77%** |

Headroom over 90% is ~1–2 points. The timeout mutants stay *detected* across runs, so the score doesn't dip toward the ~89% worst case. If a future run ever grazes the line, the fix is to kill a few of the surviving mutants (add tests) or raise Stryker's per-mutant timeout — happy to do either.

## Scope

The Stryker workflow runs on `workflow_dispatch` + a weekly schedule (mutation runs are slow), so this gates those runs — not every PR. Per-PR enforcement / score-history publishing are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)