### PR TITLE
Enable trim/AOT analyzers via IsAotCompatible (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PackageValidation, baselined against the last release (`PackageValidationBaselineVersion`), so an
   accidental breaking change fails `dotnet pack` (and therefore the release). Intentional breaks can
   be waived with an `ApiCompatSuppressionFile`.
+- **#175** — Internal: enabled the trim/AOT/single-file analyzers (`IsAotCompatible`) on the
+  net8.0/net10.0 builds, so an AOT-incompatible change fails the build. The library is AOT-clean.
 
 ### Deprecated
 

--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -31,6 +31,15 @@
 	  <SignAssembly>False</SignAssembly>
   </PropertyGroup>
 
+	<!-- Trim / AOT compatibility gate (#175): on the modern TFMs, enable the trim, AOT and
+	     single-file analyzers so an AOT-incompatible change surfaces as an IL2xxx/IL3xxx warning
+	     (and fails the build under TreatWarningsAsErrors). A library can't be AOT-published on its
+	     own, so this static analysis is the recommended verification. IsAotCompatible is only valid
+	     on net8.0+, so it is scoped away from net462 / netstandard2.0. -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+		<IsAotCompatible>true</IsAotCompatible>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<PackageTags>d20;dice</PackageTags>
 		<ApplicationIcon>assets\d20-dice.ico</ApplicationIcon>


### PR DESCRIPTION
Addresses #175 (static half — see follow-up #220 for the runtime smoke consumer).

## What

Adds `<IsAotCompatible>true</IsAotCompatible>` on the **net8.0 / net10.0** builds:

```xml
<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
  <IsAotCompatible>true</IsAotCompatible>
</PropertyGroup>
```

This turns on the **trim, AOT, and single-file analyzers**. An AOT-incompatible change now surfaces as an `IL2xxx`/`IL3xxx` warning and — under `TreatWarningsAsErrors` — fails the build.

## Verification level (honest scope)

This is **static analyzer validation**, which is the .NET-recommended way to verify a *library* (a library can't be AOT-published on its own). `dotnet build src -c Release` across all TFMs: **0 warnings, 0 errors**.

The stronger **publish-and-run `PublishAot` smoke consumer** from #175's acceptance criteria (needs a separate app + a native-toolchain CI job behind the protected-file bypass) is split out as **follow-up #220** so the analyzer gate can land now.

## Scoping

`IsAotCompatible` is only valid on net8.0+, so it's conditioned away from `net462`/`netstandard2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)