### PR TITLE
Fix InspectCode job aborting on repos with only a .sln (no .slnx)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -290,9 +290,11 @@ jobs:
         run: |
           # Find a solution to inspect. Prefer .slnx (new format) then .sln.
           # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          # `|| true` keeps a no-match `ls` (non-zero exit) from aborting the step under the
+          # `set -e -o pipefail` shell when only one of .slnx / .sln is present.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1 || true)
           if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
+            SLN=$(ls *.sln 2>/dev/null | head -n1 || true)
           fi
           if [ -z "$SLN" ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."


### PR DESCRIPTION
## Problem

The **ReSharper InspectCode** job fails on **every** PR in this repo (seen on #218, #219, and any other), with the step exiting code 2 *before `jb inspectcode` runs*.

Root cause is the solution-detection under the step's `set -e -o pipefail` shell:

```bash
SLN=$(ls *.slnx 2>/dev/null | head -n1)   # repo has D20.Dice.sln, no *.slnx
```

`ls *.slnx` exits non-zero (no match) → `pipefail` propagates it → `set -e` aborts the whole step, before the `.sln` fallback ever runs.

Not caught earlier because InspectCode isn't a required check, so PRs merged with it red.

## Fix

Add `|| true` to both `ls` lookups so a no-match exit can't abort the step. The existing "neither .slnx nor .sln found" guard still `exit 1`s intentionally.

## Verified

Simulated the detection in the repo root under `bash -e -o pipefail`: before → aborts; after → completes and resolves `SLN=D20.Dice.sln`.

## Note

- This is the canonical InspectCode job from #199/#213; the same fix should flow to `repo-template` (and any repo that has only a `.sln`).
- Workflow-only change, so it trips the protected-file guard (`Detect .NET Projects`) and needs an **admin-bypass merge**, same as #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)