### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.7.0] - 2026-07-13
+
+### Added
+
 - `AverageRoundedUp()` and `AverageRoundedDown()` extension methods on `IDie` and `IDice`,
   returning the average roll rounded to a whole number. See #49.
 
@@ -31,17 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   net8.0/net10.0 builds, so an AOT-incompatible change fails the build. This is static
   analyzer validation; a `PublishAot` publish-and-run smoke consumer is tracked as a follow-up.
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - **#177** — `Die.ToString()` and `Dice.ToString()` now format numbers with the invariant
   culture, so dice notation always uses ASCII digits and an ASCII `-` sign and round-trips
   through `Dice.TryParse` regardless of the current thread culture.
-
-### Security
 
 ## [0.6.1] - 2026-07-06
 
@@ -132,6 +140,7 @@ runtime behavior change vs v0.5.0.
   See DateTime-Extensions v1.3.1 post-mortem for what happens when this
   pin is dropped and SDK-derived AssemblyVersion changes per release.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Chris-Wolfgang/D20-Dice/releases/tag/v0.6.0

--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-	  <Version>0.6.1</Version>
+	  <Version>0.7.0</Version>
 	  <!-- API/ABI compatibility gate (#169), implemented with the SDK's ApiCompat-based
 	       PackageValidation: the packed API surface is validated against the last released version at
 	       pack time (including in release.yaml), so an accidental breaking change fails the pack. Bump


### PR DESCRIPTION
Release prep for **v0.7.0** (previous: v0.6.1).

## Version

`0.6.1 → 0.7.0` — **MINOR**, because #49 adds new public API (`AverageRoundedUp()` / `AverageRoundedDown()` on `IDie`/`IDice`). Everything else is a bug fix (#177) or internal.

## Changes in this release

**Added**
- `AverageRoundedUp()` / `AverageRoundedDown()` extensions (#49)

**Fixed**
- Invariant-culture dice notation so `ToString` round-trips through `TryParse` under any culture (#177)

**Changed (internal)**
- Allocation-free `Dice.Roll`/`MaxValue` (#179), property tests (#162), PackageValidation gate (#169), Stryker 90% gate (#168), AOT analyzers (#175)

## Release checklist

- [x] `<Version>` → 0.7.0
- [x] CHANGELOG: `[0.7.0] - 2026-07-13` + fresh `[Unreleased]` + compare link
- [x] `PackageValidationBaselineVersion` stays 0.6.1 — `dotnet pack` succeeds, no `CP0xxx` (additions are non-breaking)
- [x] Coverage 100% line / 100% branch (≥95% release bar)
- [ ] Merge this PR
- [ ] **Maintainer:** publish a GitHub Release tagged `v0.7.0` — `release.yaml` triggers on `release: published`, validates tag == `<Version>`, then packs + pushes to NuGet
- [ ] After release: bump `PackageValidationBaselineVersion` to 0.7.0 for the next cycle

## Before you publish

Confirm how `release.yaml` authenticates to NuGet for this repo (OIDC trusted publishing vs `NUGET_API_KEY`) so the push step doesn't fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)