### PR TITLE
Bump PackageValidation baseline to 0.7.0

### DIFF
--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -11,7 +11,7 @@
 	       pack time (including in release.yaml), so an accidental breaking change fails the pack. Bump
 	       the baseline on each release. Waive an intentional break with an ApiCompatSuppressionFile. -->
 	  <EnablePackageValidation>true</EnablePackageValidation>
-	  <PackageValidationBaselineVersion>0.6.1</PackageValidationBaselineVersion>
+	  <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
 	  <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	       do not need to recompile / add binding redirects on every minor/patch
 	       bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
Post-release follow-up to v0.7.0.

## What

`PackageValidationBaselineVersion`: `0.6.1` → `0.7.0`.

Now that v0.7.0 is live on NuGet, future API/ABI compatibility (the #169 gate) is validated against the current release rather than the previous one.

## Verified

`dotnet pack -c Release` restores the `0.7.0` baseline from NuGet and validates with **no `CP0xxx`** findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)