### PR TITLE
Document mutable-key constraint on Dice.GetHashCode (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **#214** — Docs: documented on `Dice.GetHashCode()` that `Dice` is mutable and must not be
+  mutated while used as a key in a hashed collection (snapshot via `ToString` for a stable key).
+
 ### Deprecated
 
 ### Removed

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -401,12 +401,24 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// Generates a hash code for this instance based on its <see cref="Modifier"/> and the multiset of
     /// dice side counts (order-independent).
     /// </summary>
+    /// <remarks>
+    /// <see cref="Dice"/> is a mutable collection: dice can be added or removed and <see cref="Modifier"/>
+    /// is settable, and both feed into this hash code (consistent with <see cref="Equals(Dice)"/>). As with
+    /// any mutable type, do not mutate a <see cref="Dice"/> instance while it is being used as a key in a
+    /// hashed collection such as <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/> or
+    /// <see cref="System.Collections.Generic.HashSet{T}"/> — doing so leaves the instance in the wrong bucket
+    /// and breaks subsequent lookups. If you need a stable key, snapshot the value first (for example the
+    /// result of <see cref="ToString"/>).
+    /// </remarks>
     /// <returns>A combined hash code.</returns>
     public override int GetHashCode()
     {
         unchecked
         {
             // Order-independent: sum the per-die hashes so equal multisets hash identically.
+            // The hash intentionally reflects the mutable Modifier / dice multiset so it stays consistent
+            // with Equals; the mutable-key caveat is documented on this method. See issue #214.
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
             var hashCode = Modifier;
             var sideSum = 0;
             foreach (var die in _dice)


### PR DESCRIPTION
Closes #214.

## Decision

Of the options in the issue, this takes **option 1 — document the constraint**. `Dice` is intentionally a mutable `ICollection<Die>` with a settable `Modifier`, and its hash reflects that mutable state to stay consistent with `Equals`. That's the same contract mutable BCL collections have; the right fix is to document the hazard rather than change the type.

## Changes

- Added a `<remarks>` block on `Dice.GetHashCode()` explaining that a `Dice` must not be mutated while used as a key in a hashed collection (`Dictionary`/`HashSet`), and suggesting `ToString()` as a stable-key snapshot.
- Suppressed the ReSharper `NonReadonlyMemberInGetHashCode` finding inline with that rationale.
- CHANGELOG note under Changed.

## Deferred

Options 2/3 (an immutable "dice expression" value type / frozen snapshot for keys) are a larger API addition — not needed for the 0.x line; can be revisited if a real use case appears.

Builds clean (0 warnings) across all src TFMs.

First of two stacked PRs; **#220** (AOT smoke consumer) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)