### PR TITLE
Add Architecture Decision Records (#182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -434,3 +434,6 @@ docfx_project/obj/
 # Generated documentation (built by CI/CD)
 docs/*
 !docs/.gitkeep
+# Architecture Decision Records are hand-written source, not generated output.
+!docs/adr/
+!docs/adr/**

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,26 @@
+# 1. Record architecture decisions
+
+## Status
+
+Accepted
+
+## Context
+
+D20-Dice is a small but long-lived library that ships to NuGet and is maintained
+across many release cycles, often by different contributors (and automated
+agents). Several non-obvious design choices — mutability, allocation behaviour,
+culture handling, AOT posture — are easy to accidentally undo in a later change
+because the *reasoning* lives only in commit messages or a reviewer's memory.
+
+## Decision
+
+We will keep Architecture Decision Records in `docs/adr/`, one Markdown file per
+decision, in the Nygard format (Context / Decision / Consequences). Records are
+immutable once accepted; a changed decision is captured as a new, superseding ADR.
+
+## Consequences
+
+- The rationale behind load-bearing choices is discoverable next to the code.
+- Reviewers can point at an ADR instead of re-litigating a settled decision.
+- There is a small ongoing cost: a genuinely architectural change should come
+  with an ADR, not just code.

--- a/docs/adr/0002-dice-is-a-mutable-collection-of-die.md
+++ b/docs/adr/0002-dice-is-a-mutable-collection-of-die.md
@@ -1,0 +1,30 @@
+# 2. `Dice` is a mutable collection of `Die`
+
+## Status
+
+Accepted
+
+## Context
+
+A dice pool needs to represent heterogeneous rolls such as `2d6 + 1d4 + 3`. Two
+shapes were possible: an immutable value type describing a fixed expression, or a
+mutable collection that can be built up and modified after construction.
+
+## Decision
+
+`Dice` implements `ICollection<Die>`: individual `Die` can be added and removed,
+and `Modifier` is settable. Equality compares the multiset of dice plus the
+modifier (order-independent), and `GetHashCode` is derived from that same state so
+it stays consistent with `Equals`.
+
+## Consequences
+
+- Callers can construct a pool imperatively (`Add`/`Remove`) or from a sequence.
+- Because the hash is derived from mutable state, a `Dice` instance must **not**
+  be mutated while it is used as a key in a hashed collection (`Dictionary`,
+  `HashSet`) — the standard mutable-key hazard. This constraint is documented on
+  `Dice.GetHashCode` (see issue #214); callers needing a stable key can snapshot
+  via `ToString()`.
+- An immutable "dice expression" value type was considered and deferred; it can be
+  added later as a separate type if a real use case appears, without changing
+  this one.

--- a/docs/adr/0003-allocation-free-roll-hot-path.md
+++ b/docs/adr/0003-allocation-free-roll-hot-path.md
@@ -1,0 +1,29 @@
+# 3. Allocation-free `Roll` hot path
+
+## Status
+
+Accepted
+
+## Context
+
+`Dice.Roll()` (and `Dice.MaxValue`) are the hot path — a simulation or game loop
+may call `Roll()` millions of times. The original implementation summed via
+`Enumerable.Sum(_dice, ...)`. Calling a LINQ operator on the `List<Die>` field
+through `IEnumerable<Die>` boxes the list's struct enumerator on the heap, so
+every call allocated.
+
+## Decision
+
+Iterate the concrete `List<Die>` directly with `foreach`, which uses the list's
+struct enumerator and allocates nothing. The `checked` context is preserved so
+overflow still throws. Allocation is guarded by tests using
+`GC.GetAllocatedBytesForCurrentThread` (net6.0+) asserting `Die.Roll`,
+`Dice.Roll`, and `Dice.MaxValue` allocate zero bytes (see issue #179).
+
+## Consequences
+
+- The roll hot path is allocation-free and GC-pressure-free.
+- New code on this path must avoid LINQ and other hidden allocations; the
+  allocation guard tests will fail if that regresses.
+- Slightly more verbose than the LINQ one-liner — an intentional trade of brevity
+  for zero allocation.

--- a/docs/adr/0004-invariant-culture-dice-notation.md
+++ b/docs/adr/0004-invariant-culture-dice-notation.md
@@ -1,0 +1,28 @@
+# 4. Invariant-culture dice notation
+
+## Status
+
+Accepted
+
+## Context
+
+`Die.ToString()` and `Dice.ToString()` emit standard dice notation (e.g.
+`2d6-1`), and `Dice.TryParse` reads it back. The parser reads with
+`CultureInfo.InvariantCulture`, but the formatters originally used the current
+thread culture (string interpolation / `StringBuilder.Append(int)`). `int`
+formatting is ASCII in every culture, but the **negative sign** is not — some
+cultures use a non-ASCII minus — so under those cultures a negative modifier
+produced notation that would not round-trip through `TryParse` (see issue #177).
+
+## Decision
+
+Both `ToString` overrides format all numbers with `CultureInfo.InvariantCulture`,
+so notation always uses ASCII digits and an ASCII `-`, independent of the current
+thread culture. A culture-matrix test plus a deterministic hostile-negative-sign
+test guard the round-trip.
+
+## Consequences
+
+- `ToString()` output is stable and always parseable, regardless of ambient culture.
+- Any future notation formatting must also use the invariant culture — the
+  globalization tests will catch a regression.

--- a/docs/adr/0005-aot-compatibility-via-analyzers.md
+++ b/docs/adr/0005-aot-compatibility-via-analyzers.md
@@ -1,0 +1,29 @@
+# 5. Verify AOT compatibility via analyzers
+
+## Status
+
+Accepted
+
+## Context
+
+Consumers may publish with Native AOT or trimming. A library cannot be
+AOT-published on its own, so it needs a way to guarantee it stays AOT/trim-safe.
+There are two complementary levers: the SDK's static analyzers, and an actual
+publish-and-run of a consumer.
+
+## Decision
+
+Enable `IsAotCompatible=true` on the net8.0/net10.0 builds of the library. This
+turns on the trim, AOT, and single-file analyzers, so an AOT-incompatible change
+surfaces as an `IL2xxx`/`IL3xxx` warning and fails the build under
+`TreatWarningsAsErrors` (issue #175). As a runtime complement, a small
+`PublishAot` smoke consumer is published and executed in CI (issue #220).
+
+## Consequences
+
+- AOT/trim regressions are caught at build time on the modern TFMs, and at
+  publish/run time in the AOT smoke workflow.
+- `IsAotCompatible` is only valid on net8.0+, so it is scoped away from
+  `net462` / `netstandard2.0`.
+- `RegexOptions.Compiled` is not flagged by the analyzers; it simply falls back
+  to interpreted under AOT at runtime, which is acceptable.

--- a/docs/adr/0006-api-compat-gate-via-packagevalidation.md
+++ b/docs/adr/0006-api-compat-gate-via-packagevalidation.md
@@ -1,0 +1,27 @@
+# 6. API/ABI compatibility gate via PackageValidation
+
+## Status
+
+Accepted
+
+## Context
+
+As a published package, D20-Dice must avoid shipping an accidental breaking
+change (a removed or changed public member, or an ABI break across target
+frameworks). The `Microsoft.DotNet.ApiCompat` engine can diff the packed API
+surface against a baseline; it is also available SDK-integrated as
+PackageValidation, with no separate tool or workflow.
+
+## Decision
+
+Enable the SDK's `EnablePackageValidation` with `PackageValidationBaselineVersion`
+set to the last released version. At `dotnet pack` time (including in
+`release.yaml`) the packed surface is validated against the baseline package from
+NuGet; an accidental break fails the pack with a `CP0xxx` error (issue #169).
+
+## Consequences
+
+- Breaking changes are caught before a release, wherever `dotnet pack` runs.
+- The baseline version must be bumped to the newly released version as part of
+  each release (a companion to the `<Version>` bump).
+- Intentional breaks can be waived with an `ApiCompatSuppressionFile`.

--- a/docs/adr/0007-mutation-testing-quality-bar.md
+++ b/docs/adr/0007-mutation-testing-quality-bar.md
@@ -1,0 +1,27 @@
+# 7. Mutation-testing quality bar (Stryker)
+
+## Status
+
+Accepted
+
+## Context
+
+Line/branch coverage confirms code is *executed* by tests, not that the tests
+would *catch a regression*. Mutation testing (Stryker.NET) measures the latter by
+introducing faults and checking whether a test fails. A Stryker workflow already
+existed but its break threshold was `0`, so it never gated on the score.
+
+## Decision
+
+Set the Stryker break threshold to **90%**: a change that drops the mutation
+score below 90% fails the run (issue #168). The run stays on `workflow_dispatch`
++ a weekly schedule rather than per-PR, because mutation runs are slow.
+
+## Consequences
+
+- Mutation score is a real quality bar, not just a report.
+- The 90% threshold has modest headroom over the measured score (~91%); if a
+  future run grazes the line the response is to kill surviving mutants (add
+  tests) or raise Stryker's per-mutant timeout, not to lower the bar silently.
+- Because the run is not per-PR, a score regression is detected on the next
+  scheduled/manual run rather than at merge time.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,22 +8,14 @@ itself, and the consequences (good and bad). ADRs are immutable once accepted �
 when a decision changes, add a **new** ADR that supersedes the old one rather
 than editing history.
 
-## Index
-
-| ADR | Title | Status |
-|-----|-------|--------|
-| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](0002-dice-is-a-mutable-collection-of-die.md) | `Dice` is a mutable collection of `Die` | Accepted |
-| [0003](0003-allocation-free-roll-hot-path.md) | Allocation-free `Roll` hot path | Accepted |
-| [0004](0004-invariant-culture-dice-notation.md) | Invariant-culture dice notation | Accepted |
-| [0005](0005-aot-compatibility-via-analyzers.md) | Verify AOT compatibility via analyzers | Accepted |
-| [0006](0006-api-compat-gate-via-packagevalidation.md) | API/ABI compatibility gate via PackageValidation | Accepted |
-| [0007](0007-mutation-testing-quality-bar.md) | Mutation-testing quality bar (Stryker) | Accepted |
+- **[index.md](index.md)** — the list of all ADRs and their status.
+- **[TEMPLATE.md](TEMPLATE.md)** — the skeleton to copy when adding one.
 
 ## Adding an ADR
 
-1. Copy the format of an existing record (Nygard style: Title, Status, Context,
-   Decision, Consequences).
-2. Number it with the next free 4-digit sequence.
-3. Set the status to `Proposed`, then `Accepted` once agreed (or `Superseded by ADR-NNNN`).
-4. Add a row to the index table above.
+1. Copy [`TEMPLATE.md`](TEMPLATE.md) to `NNNN-short-title.md`, numbering it with
+   the next free 4-digit sequence.
+2. Fill in Context / Decision / Consequences (Nygard style).
+3. Set the status to `Proposed`, then `Accepted` once agreed (or
+   `Superseded by ADR-NNNN`).
+4. Add a row to [`index.md`](index.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+This directory records the significant architecture / design decisions for
+**D20-Dice**, using lightweight [Architecture Decision Records (ADRs)](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+An ADR captures a single decision: the context that forced it, the decision
+itself, and the consequences (good and bad). ADRs are immutable once accepted —
+when a decision changes, add a **new** ADR that supersedes the old one rather
+than editing history.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-dice-is-a-mutable-collection-of-die.md) | `Dice` is a mutable collection of `Die` | Accepted |
+| [0003](0003-allocation-free-roll-hot-path.md) | Allocation-free `Roll` hot path | Accepted |
+| [0004](0004-invariant-culture-dice-notation.md) | Invariant-culture dice notation | Accepted |
+| [0005](0005-aot-compatibility-via-analyzers.md) | Verify AOT compatibility via analyzers | Accepted |
+| [0006](0006-api-compat-gate-via-packagevalidation.md) | API/ABI compatibility gate via PackageValidation | Accepted |
+| [0007](0007-mutation-testing-quality-bar.md) | Mutation-testing quality bar (Stryker) | Accepted |
+
+## Adding an ADR
+
+1. Copy the format of an existing record (Nygard style: Title, Status, Context,
+   Decision, Consequences).
+2. Number it with the next free 4-digit sequence.
+3. Set the status to `Proposed`, then `Accepted` once agreed (or `Superseded by ADR-NNNN`).
+4. Add a row to the index table above.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,22 @@
+# N. Short title of the decision
+
+## Status
+
+Proposed | Accepted | Superseded by [ADR-NNNN](NNNN-....md)
+
+## Context
+
+What is the issue or force that motivates this decision? Describe the facts and
+constraints — technical, product, or process — that are driving the choice.
+State the problem, not the solution.
+
+## Decision
+
+The change we are making, in active voice: "We will ...". Be specific enough
+that a future reader can tell whether later code still honours it.
+
+## Consequences
+
+What becomes easier or harder as a result — the good, the bad, and the neutral.
+Include any follow-up work, risks, or constraints the decision imposes (e.g. a
+test that guards it, or a rule new code must follow).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,15 @@
+# ADR Index
+
+All Architecture Decision Records for **D20-Dice**, with current status. See
+[`README.md`](README.md) for how ADRs work and [`TEMPLATE.md`](TEMPLATE.md) for
+the format to copy when adding one.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-dice-is-a-mutable-collection-of-die.md) | `Dice` is a mutable collection of `Die` | Accepted |
+| [0003](0003-allocation-free-roll-hot-path.md) | Allocation-free `Roll` hot path | Accepted |
+| [0004](0004-invariant-culture-dice-notation.md) | Invariant-culture dice notation | Accepted |
+| [0005](0005-aot-compatibility-via-analyzers.md) | Verify AOT compatibility via analyzers | Accepted |
+| [0006](0006-api-compat-gate-via-packagevalidation.md) | API/ABI compatibility gate via PackageValidation | Accepted |
+| [0007](0007-mutation-testing-quality-bar.md) | Mutation-testing quality bar (Stryker) | Accepted |


### PR DESCRIPTION
Closes #182. First of the vNext "doable maintenance" stack. **Docs only.**

## What

`docs/adr/` — an index + process ([ADR 0001](../docs/adr/0001-record-architecture-decisions.md), Nygard format) plus records for this cycle's load-bearing decisions:

| ADR | Decision |
|-----|----------|
| 0002 | `Dice` is a mutable `ICollection<Die>` (+ the mutable-key hash caveat, #214) |
| 0003 | Allocation-free `Roll` hot path (#179) |
| 0004 | Invariant-culture dice notation (#177) |
| 0005 | AOT compatibility via analyzers (#175 / #220) |
| 0006 | API/ABI compat gate via PackageValidation (#169) |
| 0007 | Mutation-testing quality bar (#168) |

## Note

`docs/*` is gitignored (generated docs), so this adds a `.gitignore` negation for `docs/adr/` — ADRs are hand-written source. No CHANGELOG entry (internal).

Targets **vNext**. Stacked: #183 (DR runbook) and #173 (Verify snapshots) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)