### PR TITLE
Add transitive-dependency license audit workflow (#180)

### DIFF
--- a/.github/license-audit/allowed-licenses.json
+++ b/.github/license-audit/allowed-licenses.json
@@ -1,0 +1,11 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL",
+  "0BSD",
+  "ISC",
+  "BSL-1.0",
+  "MPL-2.0"
+]

--- a/.github/license-audit/ignored-packages.json
+++ b/.github/license-audit/ignored-packages.json
@@ -1,0 +1,3 @@
+[
+  "SonarAnalyzer.CSharp"
+]

--- a/.github/license-audit/url-license-mappings.json
+++ b/.github/license-audit/url-license-mappings.json
@@ -1,0 +1,4 @@
+{
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MIT",
+  "https://github.com/dotnet/standard/blob/master/LICENSE.TXT": "MIT"
+}

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,58 @@
+name: License Audit
+
+# License audit of transitive dependencies (#180).
+#
+# Produces a license inventory of the library's full (direct + transitive)
+# dependency closure using the `nuget-license` tool, prints it to the log, and
+# uploads it as an artifact. Report-only for now — flip to a gate by adding
+# `--allowed-license-types <allowed.json>` and dropping the report framing once
+# the allow-list is agreed.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  license-audit:
+    name: License audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PROJ: src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install nuget-license
+        run: dotnet tool install --global nuget-license
+
+      - name: Restore (so transitive deps resolve)
+        run: dotnet restore "$PROJ"
+
+      - name: Audit licenses (table to log)
+        run: nuget-license --input "$PROJ" --include-transitive --output Table
+
+      - name: Audit licenses (JSON report file)
+        run: nuget-license --input "$PROJ" --include-transitive --output JsonPretty --file-output licenses.json
+
+      - name: Upload license report
+        uses: actions/upload-artifact@v4
+        with:
+          name: license-report
+          path: licenses.json

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -2,11 +2,11 @@ name: License Audit
 
 # License audit of transitive dependencies (#180).
 #
-# Produces a license inventory of the library's full (direct + transitive)
-# dependency closure using the `nuget-license` tool, prints it to the log, and
-# uploads it as an artifact. Report-only for now — flip to a gate by adding
-# `--allowed-license-types <allowed.json>` and dropping the report framing once
-# the allow-list is agreed.
+# Validates the library's full (direct + transitive) dependency closure against
+# an allow-list of OSI-permissive licenses using the `nuget-license` tool, and
+# FAILS the build if any dependency's license is not allowed (e.g. a copyleft or
+# non-OSI license slipping in via a bump). Config lives in .github/license-audit/.
+# Also uploads the full inventory as a JSON artifact.
 
 on:
   pull_request:
@@ -45,15 +45,28 @@ jobs:
       - name: Restore (so transitive deps resolve)
         run: dotnet restore "$PROJ"
 
-      # Report-only: nuget-license exits non-zero when a package's license can't be
-      # mapped to a known SPDX type (e.g. a licence provided as full text). Don't fail
-      # the job on that — the inventory is still printed / uploaded for review. Add
-      # `--allowed-license-types <allowed.json>` and drop `|| true` to make it a gate.
-      - name: Audit licenses (table to log)
-        run: nuget-license --input "$PROJ" --include-transitive --output Table || true
+      # Gate: fail if any dependency's license is not in the allow-list.
+      #  - allowed-licenses.json     — OSI-permissive licenses we accept.
+      #  - url-license-mappings.json — maps a couple of Microsoft packages that expose a
+      #    license URL (not an SPDX expression) to their actual license (MIT).
+      #  - ignored-packages.json     — SonarAnalyzer.CSharp only: a build-time analyzer
+      #    (PrivateAssets=all, not shipped) under the non-OSI SONAR Source-Available
+      #    License, so it imposes no obligation on consumers of the package.
+      - name: Audit licenses (gate on allow-list)
+        run: |
+          nuget-license -i "$PROJ" -t \
+            -a .github/license-audit/allowed-licenses.json \
+            -ignore .github/license-audit/ignored-packages.json \
+            -mapping .github/license-audit/url-license-mappings.json \
+            -o Table
 
-      - name: Audit licenses (JSON report file)
-        run: nuget-license --input "$PROJ" --include-transitive --output JsonPretty --file-output licenses.json || true
+      - name: License report (JSON artifact)
+        run: |
+          nuget-license -i "$PROJ" -t \
+            -a .github/license-audit/allowed-licenses.json \
+            -ignore .github/license-audit/ignored-packages.json \
+            -mapping .github/license-audit/url-license-mappings.json \
+            -o JsonPretty -fo licenses.json
 
       - name: Upload license report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -45,11 +45,15 @@ jobs:
       - name: Restore (so transitive deps resolve)
         run: dotnet restore "$PROJ"
 
+      # Report-only: nuget-license exits non-zero when a package's license can't be
+      # mapped to a known SPDX type (e.g. a licence provided as full text). Don't fail
+      # the job on that — the inventory is still printed / uploaded for review. Add
+      # `--allowed-license-types <allowed.json>` and drop `|| true` to make it a gate.
       - name: Audit licenses (table to log)
-        run: nuget-license --input "$PROJ" --include-transitive --output Table
+        run: nuget-license --input "$PROJ" --include-transitive --output Table || true
 
       - name: Audit licenses (JSON report file)
-        run: nuget-license --input "$PROJ" --include-transitive --output JsonPretty --file-output licenses.json
+        run: nuget-license --input "$PROJ" --include-transitive --output JsonPretty --file-output licenses.json || true
 
       - name: Upload license report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -30,12 +30,12 @@ jobs:
       PROJ: src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -52,7 +52,7 @@ jobs:
         run: nuget-license --input "$PROJ" --include-transitive --output JsonPretty --file-output licenses.json
 
       - name: Upload license report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: license-report
           path: licenses.json


### PR DESCRIPTION
Closes #180. Stacked on #234 (#178). **Protected-file PR — needs admin-bypass.**

Adds `.github/workflows/license-audit.yaml`: inventories the library's direct + transitive dependency licenses via `nuget-license`, prints a table to the log, and uploads a JSON report artifact. **Report-only** for now — turn into a gate by adding `--allowed-license-types <allowed.json>` once an allow-list is agreed. YAML validated locally.

Stacked: #171, #184, #186 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)