### PR TITLE
Add CycloneDX SBOM generation workflow (#171)

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,58 @@
+name: SBOM
+
+# Supply-chain hardening — Software Bill of Materials (#171).
+#
+# Generates a CycloneDX SBOM of the library's full dependency graph and uploads
+# it as an artifact, so every build has a machine-readable inventory of what it
+# is composed of. Scoped to the SBOM here; the other parts of #171 are
+# deliberately out of this workflow:
+#   - SLSA provenance attestation belongs on the release artifact (attest the
+#     packed .nupkg in release.yaml via actions/attest-build-provenance).
+#   - Package signing needs a signing certificate/key and is a separate,
+#     credential-bearing change.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PROJ: src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install CycloneDX
+        run: dotnet tool install --global CycloneDX
+
+      - name: Restore
+        run: dotnet restore "$PROJ"
+
+      - name: Generate CycloneDX SBOM (JSON)
+        run: dotnet CycloneDX "$PROJ" --output sbom --json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom/

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -33,12 +33,12 @@ jobs:
       PROJ: src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -52,7 +52,7 @@ jobs:
         run: dotnet CycloneDX "$PROJ" --output sbom --json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom
           path: sbom/


### PR DESCRIPTION
Closes #171. Stacked on #235 (#180). **Protected-file PR — needs admin-bypass.**

Adds `.github/workflows/sbom.yaml`: generates a CycloneDX SBOM of the library's dependency graph and uploads it as an artifact — a machine-readable bill of materials for every build.

**Scoped to the SBOM.** The other two parts of #171 are deliberately out of this workflow and left as follow-ups:
- **SLSA provenance attestation** belongs on the release artifact (attest the packed `.nupkg` in `release.yaml` via `actions/attest-build-provenance`).
- **Package signing** needs a signing certificate/key — a separate credential-bearing change.

YAML validated locally.

Stacked: #184, #186 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)