### PR TITLE
Add AOT smoke workflow (split from #226)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,50 @@
+name: AOT Smoke
+
+# Native-AOT publish-and-run smoke consumer (#220, follow-up to #175).
+#
+# Publishes a tiny console consumer with PublishAot and runs the native binary,
+# so the build fails if the library stops compiling or running under native AOT.
+# This is the *runtime* half of the AOT verification; the *static* half is the
+# IsAotCompatible analyzer gate on the library build (#175).
+#
+# windows-latest ships the MSVC "Desktop development with C++" workload that the
+# native linker requires, so no extra toolchain install is needed.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aot-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aot-smoke:
+    name: "AOT publish + run"
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish (native AOT, win-x64)
+        run: dotnet publish aot-smoke/Wolfgang.D20.Dice.AotSmoke/Wolfgang.D20.Dice.AotSmoke.csproj -c Release -r win-x64
+
+      - name: Run native binary
+        shell: bash
+        run: |
+          EXE="aot-smoke/Wolfgang.D20.Dice.AotSmoke/bin/Release/net10.0/win-x64/publish/Wolfgang.D20.Dice.AotSmoke.exe"
+          echo "Running: $EXE"
+          "$EXE"


### PR DESCRIPTION
Protected-file split from #226 (part of #220).

## Why

#226 bundled the `aot-smoke.yaml` workflow (a protected `.github/workflows/*` file) with the non-protected aot-smoke project. That trips the `Detect .NET Projects` guard and would force an admin-bypass on the whole PR. This PR carries **only** the workflow so:
- **#226** keeps just the project + CHANGELOG and merges **without** a bypass;
- this one-file PR gets the **admin-bypass** (same pattern as #213/#221).

## Ordering

**Merge this AFTER #226.** The workflow publishes the `aot-smoke` project that #226 adds — merging the workflow first would make it fail on `main` (project not present).

Actions are SHA-pinned per the fleet policy. `Closes #220`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)