### PR TITLE
Switch release publish to OIDC / NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -672,6 +672,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org (Trusted Publishing)
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -691,22 +694,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,9 +26,14 @@ Responsible disclosure of security vulnerabilities helps protect our entire comm
 
 Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook. The fleet-canonical full runbook is tracked at [Chris-Wolfgang/repo-template#430](https://github.com/Chris-Wolfgang/repo-template/issues/430).
 
-- **Release path**: NuGet **API key**. `.github/workflows/release.yaml` (triggered on `release: published`) pushes with the long-lived `NUGET_API_KEY` GitHub Actions secret. That secret **is** the standing release credential — during an incident, delete the `NUGET_API_KEY` repo secret and revoke/rotate the corresponding key on nuget.org, then check the NuGet account for any other long-lived API keys and delete anything you don't recognize.
-- **Fallback**: none. If the release credential is compromised, the incident is at the GitHub-account / NuGet-account level.
-- **Hardening direction**: migrating to OIDC / NuGet Trusted Publishing (via `NuGet/login@v1`, as piloted on ETL-SqlBulkCopy) would remove this standing secret entirely.
+- **Release path**: OIDC / NuGet **Trusted Publishing** via `NuGet/login@v1` in
+  `.github/workflows/release.yaml` (triggered on `release: published`). The workflow mints an
+  ephemeral push token per run via OIDC — the release path does **not** depend on a long-lived
+  `NUGET_API_KEY` in GitHub secrets or on the NuGet account. During an incident, check the NuGet
+  account for any long-lived API keys anyway (they can be created outside CI) and delete anything
+  you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account
+  level (the OIDC identity is `Chris-Wolfgang/D20-Dice`).
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: none known inside the Wolfgang.* org at time of writing; the package is public on nuget.org, so unknown downstream consumers may exist. Re-check via `dotnet-outdated`, GitHub code-search, and the NuGet package's `Used By` dependents list before communicating during an incident.
 - **Package coordinates for unlisting**: `Wolfgang.D20.Dice` on nuget.org — <https://www.nuget.org/packages/Wolfgang.D20.Dice/>.


### PR DESCRIPTION
**⚠️ Merge before publishing v0.7.1** — the `NUGET_API_KEY` secret was deleted and Trusted Publishing set up, so the current `release.yaml` would **fail** (its `NUGET_API_KEY`-configured check + `--api-key` push).

## Changes

- **`release.yaml`** (publish job):
  - `permissions: id-token: write` (OIDC token issuance).
  - Replace the "Validate NUGET_API_KEY" step with **`NuGet/login@v1`** (SHA-pinned, `user: Chris-Wolfgang`) — mints a short-lived push token per run.
  - Push with `${{ steps.nuget-login.outputs.NUGET_API_KEY }}` instead of `secrets.NUGET_API_KEY`.
- **`SECURITY.md`** — release-scope appendix now describes the OIDC path (no standing secret; OIDC identity `Chris-Wolfgang/D20-Dice`); dropped the "hardening direction" note (now done).

Models the already-migrated `Etl-DbClient` release.yaml. YAML validated; no `secrets.NUGET_API_KEY` references remain.

## Heads-up
- **Protected-file PR** (`.github/workflows/*`) → needs **admin-bypass**.
- After this merges, publish the **v0.7.1** Release — `release.yaml` will authenticate via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)