### PR TITLE
Run Actions-audit on every PR (enable actionlint as a required check)

### DIFF
--- a/.github/workflows/actions-audit.yaml
+++ b/.github/workflows/actions-audit.yaml
@@ -13,11 +13,12 @@ name: Actions Audit
 # wrapper actions, to keep the supply chain small.
 
 on:
+  # Runs on every PR (not path-filtered) so the actionlint job can be a required
+  # status check — a path-filtered required check would hang PRs that don't touch
+  # .github/workflows/**. actionlint/zizmor are cheap (~20s) and idempotent.
   pull_request:
-    paths: ['.github/workflows/**']
   push:
     branches: [main]
-    paths: ['.github/workflows/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**Protected-file PR — needs admin-bypass.**

Removes the `.github/workflows/**` path filter from `actions-audit.yaml` so the **actionlint** job runs on **every** PR. This is required to make it a required status check — a path-filtered check stays "pending" forever on PRs that don't match the path, blocking merge.

actionlint + zizmor are cheap (~20s) and idempotent, so running them on every PR is fine.

## Follow-up
After this merges, `actionlint` gets added to the `main` ruleset required checks (joining `License audit`, `Reproducible build`, `AOT publish + run`, already added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)