### PR TITLE
docs: add <example> blocks to public API XML docs (#174)

### DIFF
--- a/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
+++ b/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
@@ -20,6 +20,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded up.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Die(6).AverageRoundedUp(); // 3.5 -> 4
+    /// </code>
+    /// </example>
     public static int AverageRoundedUp(this IDie die)
     {
         if (die is null)
@@ -40,6 +45,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded up.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Dice(2, 6).AverageRoundedUp(); // 7.0 -> 7
+    /// </code>
+    /// </example>
     public static int AverageRoundedUp(this IDice dice)
     {
         if (dice is null)
@@ -60,6 +70,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded down.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Die(6).AverageRoundedDown(); // 3.5 -> 3
+    /// </code>
+    /// </example>
     public static int AverageRoundedDown(this IDie die)
     {
         if (die is null)
@@ -80,6 +95,12 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded down.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// // 2d6 averages 7; half damage on a successful save, rounded down, is 3.
+    /// int half = new Dice(2, 6).AverageRoundedDown() / 2; // 3
+    /// </code>
+    /// </example>
     public static int AverageRoundedDown(this IDice dice)
     {
         if (dice is null)

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -32,6 +32,13 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// This convenience constructor builds a homogeneous collection of <paramref name="dieCount"/> dice,
     /// each with <paramref name="sideCount"/> sides. A sideCount of 2 represents a coin toss.
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// // 2d6+3: two six-sided dice plus a flat +3.
+    /// var attack = new Dice(dieCount: 2, sideCount: 6, modifier: 3);
+    /// int total = attack.Roll(); // a value in [5, 15]
+    /// </code>
+    /// </example>
     public Dice(int dieCount = 1, int sideCount = 6, int modifier = 0)
     {
         if (dieCount < 1)
@@ -62,6 +69,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// <param name="modifier">An optional modifier to add to the result</param>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null</exception>
     /// <exception cref="ArgumentException"><paramref name="dice"/> contains a null element</exception>
+    /// <example>
+    /// <code>
+    /// // 1d6+1d4+1: a heterogeneous pool built from individual dice.
+    /// var dice = new Dice(new[] { new Die(6), new Die(4) }, modifier: 1);
+    /// </code>
+    /// </example>
     public Dice(IEnumerable<Die> dice, int modifier = 0)
     {
         if (dice is null)
@@ -109,6 +122,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// <remarks>
     /// The value can be positive or negative, and can be used to adjust the result of the roll.
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var dice = new Dice(1, 20) { Modifier = 5 }; // 1d20+5
+    /// int total = dice.Roll(); // a value in [6, 25]
+    /// </code>
+    /// </example>
     public int Modifier { get; set; }
 
 
@@ -160,6 +179,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// The sum of an independent roll of each die in the collection plus <see cref="Modifier"/>.
     /// Always between <see cref="MinValue"/> and <see cref="MaxValue"/> inclusive.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var dice = new Dice(3, 6); // 3d6
+    /// int total = dice.Roll(); // a value in [3, 18]
+    /// </code>
+    /// </example>
     public int Roll()
     {
         checked
@@ -293,6 +318,11 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// modifier renders with a leading minus sign. An empty collection renders only the modifier
     /// (or an empty string when the modifier is zero).
     /// </returns>
+    /// <example>
+    /// <code>
+    /// string notation = new Dice(2, 6, 3).ToString(); // "2d6+3"
+    /// </code>
+    /// </example>
     public override string ToString()
     {
         var builder = new StringBuilder();
@@ -454,6 +484,16 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// otherwise, a failed result with <see cref="Wolfgang.TryPattern.Result.ErrorMessage"/> describing the failure.
     /// Accessing <see cref="Wolfgang.TryPattern.Result{T}.Value"/> on a failed result throws <see cref="InvalidOperationException"/>.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var result = Dice.TryParse("2d6+3");
+    /// if (result.Succeeded)
+    /// {
+    ///     Dice dice = result.Value!;
+    ///     int total = dice.Roll(); // a value in [5, 15]
+    /// }
+    /// </code>
+    /// </example>
     public static Result<Dice?> TryParse(string? notation)
     {
         if (string.IsNullOrWhiteSpace(notation))

--- a/src/Wolfgang.D20.Dice/Die.cs
+++ b/src/Wolfgang.D20.Dice/Die.cs
@@ -19,6 +19,12 @@ public sealed class Die : IDie, IEquatable<Die>
     /// <param name="sideCount">The number of sides on the die</param>
     /// <exception cref="ArgumentOutOfRangeException">sideCount is less than 2</exception>
     /// <remarks>sideCount of 2 represents a coin toss</remarks>
+    /// <example>
+    /// <code>
+    /// var d20 = new Die(20);
+    /// int result = d20.Roll(); // a value in [1, 20]
+    /// </code>
+    /// </example>
     public Die(int sideCount = 6)
     {
         if (sideCount < 2)
@@ -60,6 +66,12 @@ public sealed class Die : IDie, IEquatable<Die>
     /// <returns>
     /// A uniform random value in [<see cref="MinValue"/>, <see cref="MaxValue"/>] inclusive.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var d6 = new Die(6);
+    /// int result = d6.Roll(); // a value in [1, 6]
+    /// </code>
+    /// </example>
     public int Roll()
     {
 #if NET6_0_OR_GREATER
@@ -76,6 +88,11 @@ public sealed class Die : IDie, IEquatable<Die>
     /// Returns a string representation of the die in the format "dY" where Y is the number of sides.
     /// </summary>
     /// <returns>The die in standard <c>dY</c> notation.</returns>
+    /// <example>
+    /// <code>
+    /// string notation = new Die(20).ToString(); // "d20"
+    /// </code>
+    /// </example>
     public override string ToString()
     {
         // Format the side count with the invariant culture so the notation always uses ASCII digits and

--- a/src/Wolfgang.D20.Dice/IDice.cs
+++ b/src/Wolfgang.D20.Dice/IDice.cs
@@ -7,6 +7,12 @@ namespace Wolfgang.D20;
 /// The dice need not be homogeneous; a single <see cref="Dice"/> can contain dice with differing
 /// side counts, for example <c>2d6+1d4+3</c>.
 /// </remarks>
+/// <example>
+/// <code>
+/// IDice dice = new Dice(2, 6, 3); // 2d6+3
+/// int total = dice.Roll(); // a value in [5, 15]
+/// </code>
+/// </example>
 public interface IDice
 {
 

--- a/src/Wolfgang.D20.Dice/IDie.cs
+++ b/src/Wolfgang.D20.Dice/IDie.cs
@@ -3,6 +3,12 @@ namespace Wolfgang.D20;
 /// <summary>
 /// Represents a single die with a fixed number of sides.
 /// </summary>
+/// <example>
+/// <code>
+/// IDie die = new Die(20);
+/// int result = die.Roll(); // a value in [1, 20]
+/// </code>
+/// </example>
 public interface IDie
 {
 


### PR DESCRIPTION
Resolves the reframed **#174** — the public API had complete `<summary>`/`<returns>`/`<remarks>` docs but no `<example>` blocks. This adds runnable examples to the key public members so consumers see how each entry point is called.

## Members given `<example>` blocks
- **`Die`** — constructor, `Roll()`, `ToString()`
- **`Dice`** — convenience ctor, sequence ctor, `Roll()`, `Modifier`, `TryParse(...)`, `ToString()`
- **`IDie` / `IDice`** — class-level usage examples
- **`AverageRollExtensions`** — `AverageRoundedUp`/`AverageRoundedDown` (both `IDie` and `IDice` overloads)

## Verification
XML doc blocks aren't compiled by the normal build, so every snippet was extracted into a throwaway console project, `ProjectReference`d against the library, and built under `TreatWarningsAsErrors=true` — **0 warnings, 0 errors**. Running it confirmed the commented outputs are exact: `d20`, `1d6+1d4+1`, `2d6+3`, and averages `4 / 7 / 3`.

Docs-only: no API surface, behaviour, or version change.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)