### PR TITLE
ci: attest SLSA build provenance for published packages (#171)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -703,7 +703,7 @@ jobs:
       # Package *signing* (an author signature) is intentionally out of scope — it needs a
       # code-signing certificate.
       - name: Attest build provenance for packages
-        uses: actions/attest-build-provenance@78e6cbd37d0ac1a40113c04f2037dacf1ea3f12e # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: './packages/*.nupkg'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -673,7 +673,8 @@ jobs:
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     permissions:
-      id-token: write   # required for OIDC token issuance to nuget.org (Trusted Publishing)
+      id-token: write       # required for OIDC token issuance to nuget.org (Trusted Publishing) AND for SLSA provenance signing
+      attestations: write   # required to record the SLSA build-provenance attestation on GitHub (#171)
       contents: read
     steps:
       - name: Setup .NET
@@ -693,6 +694,18 @@ jobs:
         with:
           name: nuget-packages
           path: ./packages
+
+      # SLSA build provenance (#171): generate a signed attestation binding each packed
+      # .nupkg (by SHA-256 digest) to the exact repo, commit and workflow run that produced
+      # it. Uses the workflow's OIDC identity — no signing key to manage (same keyless trust
+      # model as NuGet Trusted Publishing below). Attest BEFORE pushing so the provenance
+      # covers the exact bytes we publish; consumers verify with `gh attestation verify`.
+      # Package *signing* (an author signature) is intentionally out of scope — it needs a
+      # code-signing certificate.
+      - name: Attest build provenance for packages
+        uses: actions/attest-build-provenance@78e6cbd37d0ac1a40113c04f2037dacf1ea3f12e # v4
+        with:
+          subject-path: './packages/*.nupkg'
 
       - name: NuGet login (OIDC → temporary API key)
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,28 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: none known inside the Wolfgang.* org at time of writing; the package is public on nuget.org, so unknown downstream consumers may exist. Re-check via `dotnet-outdated`, GitHub code-search, and the NuGet package's `Used By` dependents list before communicating during an incident.
 - **Package coordinates for unlisting**: `Wolfgang.D20.Dice` on nuget.org — <https://www.nuget.org/packages/Wolfgang.D20.Dice/>.
+
+## Verifying a release
+
+Every published release carries supply-chain evidence so consumers can prove a package
+was built from this repository and not tampered with:
+
+- **SLSA build provenance** — `release.yaml` generates a signed [SLSA](https://slsa.dev)
+  provenance attestation for each `.nupkg` via `actions/attest-build-provenance`, using the
+  workflow's OIDC identity (`Chris-Wolfgang/D20-Dice`). The attestation binds the package's
+  SHA-256 digest to the exact commit and workflow run that produced it. To verify a
+  downloaded package with the [GitHub CLI](https://cli.github.com/):
+
+  ```bash
+  gh attestation verify Wolfgang.D20.Dice.<version>.nupkg --repo Chris-Wolfgang/D20-Dice
+  ```
+
+  A successful verification confirms the package was built by this repo's release workflow.
+- **SBOM** — a CycloneDX Software Bill of Materials (`Wolfgang.D20.Dice.bom.json`) is
+  generated at release time and attached to the GitHub Release, giving a machine-readable
+  inventory of the package's full dependency closure.
+
+> **Not yet author-signed.** The `.nupkg` does not currently carry a NuGet author signature
+> (`nuget verify` / trusted-signers), because that requires a code-signing certificate. NuGet
+> still applies its own repository signature on publish. Author signing is tracked in
+> [#171](https://github.com/Chris-Wolfgang/D20-Dice/issues/171).


### PR DESCRIPTION
Adds **SLSA build-provenance attestation** to the release pipeline — the doable slice of #171's supply-chain hardening.

## What changed
`release.yaml` → `publish-nuget` job:
- New step **Attest build provenance for packages** runs [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) (SHA-pinned to `78e6cbd…` / v4) over `./packages/*.nupkg` **before** the NuGet push, so the attestation covers the exact bytes that get published.
- Adds `attestations: write` to the job (it already had `id-token: write` for OIDC Trusted Publishing, which the attestation signing reuses — **no signing key to manage**).

`SECURITY.md` → new **"Verifying a release"** section:
- How consumers verify provenance: `gh attestation verify Wolfgang.D20.Dice.<version>.nupkg --repo Chris-Wolfgang/D20-Dice`.
- Points at the CycloneDX **SBOM** already attached to each Release.
- Explicit note that the package is **not yet author-signed** (needs a certificate), tracked in #171.

## Scope vs. #171
| AC item | Status |
|---|---|
| SBOM at release time | ✅ already in `release.yaml` |
| SLSA provenance attestation | ✅ **this PR** |
| Consumer-verification docs in `SECURITY.md` | ✅ **this PR** |
| NuGet author signing (`nuget verify`) | ⛔ blocked — needs a code-signing certificate |

Because author signing remains, **#171 stays open** — this PR does not close it.

## Verification
- `release.yaml` parses as valid YAML; the `actions-audit` (actionlint) check runs on this PR and validates the workflow. The attestation step itself only exercises on an actual `release: published` run, where it will emit a verifiable attestation for the published `.nupkg`.
- Action pinned by commit SHA per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)