### PR TITLE
release: v0.7.2 — public-API examples + release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.7.2] - 2026-07-16
+
+Maintenance round — public-API documentation plus supply-chain and debug-tooling
+verification. **No public API or runtime behavior change vs 0.7.1.**
+
+### Added
+
+- **#174** — runnable `<example>` blocks on the public API XML docs (`Die`, `Dice`,
+  `IDie`/`IDice`, and the `AverageRoundedUp`/`AverageRoundedDown` extensions). Every
+  snippet is compile-verified against the library.
+- **#171** — SLSA build-provenance attestation for the published `.nupkg`
+  (`actions/attest-build-provenance`, keyless via the release workflow's OIDC identity),
+  binding each package's digest to the exact commit and workflow run that built it. A new
+  "Verifying a release" section in `SECURITY.md` documents `gh attestation verify` and the
+  CycloneDX SBOM. (NuGet author signing remains tracked in #171 — it needs a certificate.)
+- **#176** — a SourceLink verification gate (`dotnet sourcelink test`) that fetches every
+  PDB source document from GitHub and checksum-matches it, so consumer debug step-into
+  cannot silently regress to decompiled source on a mis-tagged or mis-uploaded release.
+
 ## [0.7.1] - 2026-07-15
 
 Maintenance round — repo hardening, documentation, and internal tests. **No public
@@ -171,7 +190,8 @@ runtime behavior change vs v0.5.0.
   See DateTime-Extensions v1.3.1 post-mortem for what happens when this
   pin is dropped and SDK-derived AssemblyVersion changes per release.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Chris-Wolfgang/D20-Dice/compare/v0.6.0...v0.6.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,28 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: none known inside the Wolfgang.* org at time of writing; the package is public on nuget.org, so unknown downstream consumers may exist. Re-check via `dotnet-outdated`, GitHub code-search, and the NuGet package's `Used By` dependents list before communicating during an incident.
 - **Package coordinates for unlisting**: `Wolfgang.D20.Dice` on nuget.org — <https://www.nuget.org/packages/Wolfgang.D20.Dice/>.
+
+## Verifying a release
+
+Every published release carries supply-chain evidence so consumers can prove a package
+was built from this repository and not tampered with:
+
+- **SLSA build provenance** — `release.yaml` generates a signed [SLSA](https://slsa.dev)
+  provenance attestation for each `.nupkg` via `actions/attest-build-provenance`, using the
+  workflow's OIDC identity (`Chris-Wolfgang/D20-Dice`). The attestation binds the package's
+  SHA-256 digest to the exact commit and workflow run that produced it. To verify a
+  downloaded package with the [GitHub CLI](https://cli.github.com/):
+
+  ```bash
+  gh attestation verify Wolfgang.D20.Dice.<version>.nupkg --repo Chris-Wolfgang/D20-Dice
+  ```
+
+  A successful verification confirms the package was built by this repo's release workflow.
+- **SBOM** — a CycloneDX Software Bill of Materials (`Wolfgang.D20.Dice.bom.json`) is
+  generated at release time and attached to the GitHub Release, giving a machine-readable
+  inventory of the package's full dependency closure.
+
+> **Not yet author-signed.** The `.nupkg` does not currently carry a NuGet author signature
+> (`nuget verify` / trusted-signers), because that requires a code-signing certificate. NuGet
+> still applies its own repository signature on publish. Author signing is tracked in
+> [#171](https://github.com/Chris-Wolfgang/D20-Dice/issues/171).

--- a/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
+++ b/src/Wolfgang.D20.Dice/AverageRollExtensions.cs
@@ -20,6 +20,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded up.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Die(6).AverageRoundedUp(); // 3.5 -> 4
+    /// </code>
+    /// </example>
     public static int AverageRoundedUp(this IDie die)
     {
         if (die is null)
@@ -40,6 +45,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded up.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Dice(2, 6).AverageRoundedUp(); // 7.0 -> 7
+    /// </code>
+    /// </example>
     public static int AverageRoundedUp(this IDice dice)
     {
         if (dice is null)
@@ -60,6 +70,11 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDie.MinValue"/> and <see cref="IDie.MaxValue"/>, rounded down.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="die"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// int average = new Die(6).AverageRoundedDown(); // 3.5 -> 3
+    /// </code>
+    /// </example>
     public static int AverageRoundedDown(this IDie die)
     {
         if (die is null)
@@ -80,6 +95,12 @@ public static class AverageRollExtensions
     /// The midpoint of <see cref="IDice.MinValue"/> and <see cref="IDice.MaxValue"/>, rounded down.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// // 2d6 averages 7; half damage on a successful save, rounded down, is 3.
+    /// int half = new Dice(2, 6).AverageRoundedDown() / 2; // 3
+    /// </code>
+    /// </example>
     public static int AverageRoundedDown(this IDice dice)
     {
         if (dice is null)

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -32,6 +32,13 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// This convenience constructor builds a homogeneous collection of <paramref name="dieCount"/> dice,
     /// each with <paramref name="sideCount"/> sides. A sideCount of 2 represents a coin toss.
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// // 2d6+3: two six-sided dice plus a flat +3.
+    /// var attack = new Dice(dieCount: 2, sideCount: 6, modifier: 3);
+    /// int total = attack.Roll(); // a value in [5, 15]
+    /// </code>
+    /// </example>
     public Dice(int dieCount = 1, int sideCount = 6, int modifier = 0)
     {
         if (dieCount < 1)
@@ -62,6 +69,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// <param name="modifier">An optional modifier to add to the result</param>
     /// <exception cref="ArgumentNullException"><paramref name="dice"/> is null</exception>
     /// <exception cref="ArgumentException"><paramref name="dice"/> contains a null element</exception>
+    /// <example>
+    /// <code>
+    /// // 1d6+1d4+1: a heterogeneous pool built from individual dice.
+    /// var dice = new Dice(new[] { new Die(6), new Die(4) }, modifier: 1);
+    /// </code>
+    /// </example>
     public Dice(IEnumerable<Die> dice, int modifier = 0)
     {
         if (dice is null)
@@ -109,6 +122,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// <remarks>
     /// The value can be positive or negative, and can be used to adjust the result of the roll.
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var dice = new Dice(1, 20) { Modifier = 5 }; // 1d20+5
+    /// int total = dice.Roll(); // a value in [6, 25]
+    /// </code>
+    /// </example>
     public int Modifier { get; set; }
 
 
@@ -160,6 +179,12 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// The sum of an independent roll of each die in the collection plus <see cref="Modifier"/>.
     /// Always between <see cref="MinValue"/> and <see cref="MaxValue"/> inclusive.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var dice = new Dice(3, 6); // 3d6
+    /// int total = dice.Roll(); // a value in [3, 18]
+    /// </code>
+    /// </example>
     public int Roll()
     {
         checked
@@ -293,6 +318,11 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// modifier renders with a leading minus sign. An empty collection renders only the modifier
     /// (or an empty string when the modifier is zero).
     /// </returns>
+    /// <example>
+    /// <code>
+    /// string notation = new Dice(2, 6, 3).ToString(); // "2d6+3"
+    /// </code>
+    /// </example>
     public override string ToString()
     {
         var builder = new StringBuilder();
@@ -454,6 +484,16 @@ public sealed class Dice : IDice, ICollection<Die>, IEquatable<Dice>
     /// otherwise, a failed result with <see cref="Wolfgang.TryPattern.Result.ErrorMessage"/> describing the failure.
     /// Accessing <see cref="Wolfgang.TryPattern.Result{T}.Value"/> on a failed result throws <see cref="InvalidOperationException"/>.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var result = Dice.TryParse("2d6+3");
+    /// if (result.Succeeded)
+    /// {
+    ///     Dice dice = result.Value!;
+    ///     int total = dice.Roll(); // a value in [5, 15]
+    /// }
+    /// </code>
+    /// </example>
     public static Result<Dice?> TryParse(string? notation)
     {
         if (string.IsNullOrWhiteSpace(notation))

--- a/src/Wolfgang.D20.Dice/Die.cs
+++ b/src/Wolfgang.D20.Dice/Die.cs
@@ -19,6 +19,12 @@ public sealed class Die : IDie, IEquatable<Die>
     /// <param name="sideCount">The number of sides on the die</param>
     /// <exception cref="ArgumentOutOfRangeException">sideCount is less than 2</exception>
     /// <remarks>sideCount of 2 represents a coin toss</remarks>
+    /// <example>
+    /// <code>
+    /// var d20 = new Die(20);
+    /// int result = d20.Roll(); // a value in [1, 20]
+    /// </code>
+    /// </example>
     public Die(int sideCount = 6)
     {
         if (sideCount < 2)
@@ -60,6 +66,12 @@ public sealed class Die : IDie, IEquatable<Die>
     /// <returns>
     /// A uniform random value in [<see cref="MinValue"/>, <see cref="MaxValue"/>] inclusive.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var d6 = new Die(6);
+    /// int result = d6.Roll(); // a value in [1, 6]
+    /// </code>
+    /// </example>
     public int Roll()
     {
 #if NET6_0_OR_GREATER
@@ -76,6 +88,11 @@ public sealed class Die : IDie, IEquatable<Die>
     /// Returns a string representation of the die in the format "dY" where Y is the number of sides.
     /// </summary>
     /// <returns>The die in standard <c>dY</c> notation.</returns>
+    /// <example>
+    /// <code>
+    /// string notation = new Die(20).ToString(); // "d20"
+    /// </code>
+    /// </example>
     public override string ToString()
     {
         // Format the side count with the invariant culture so the notation always uses ASCII digits and

--- a/src/Wolfgang.D20.Dice/IDice.cs
+++ b/src/Wolfgang.D20.Dice/IDice.cs
@@ -7,6 +7,12 @@ namespace Wolfgang.D20;
 /// The dice need not be homogeneous; a single <see cref="Dice"/> can contain dice with differing
 /// side counts, for example <c>2d6+1d4+3</c>.
 /// </remarks>
+/// <example>
+/// <code>
+/// IDice dice = new Dice(2, 6, 3); // 2d6+3
+/// int total = dice.Roll(); // a value in [5, 15]
+/// </code>
+/// </example>
 public interface IDice
 {
 

--- a/src/Wolfgang.D20.Dice/IDie.cs
+++ b/src/Wolfgang.D20.Dice/IDie.cs
@@ -3,6 +3,12 @@ namespace Wolfgang.D20;
 /// <summary>
 /// Represents a single die with a fixed number of sides.
 /// </summary>
+/// <example>
+/// <code>
+/// IDie die = new Die(20);
+/// int result = die.Roll(); // a value in [1, 20]
+/// </code>
+/// </example>
 public interface IDie
 {
 

--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-	  <Version>0.7.1</Version>
+	  <Version>0.7.2</Version>
 	  <!-- API/ABI compatibility gate (#169), implemented with the SDK's ApiCompat-based
 	       PackageValidation: the packed API surface is validated against the last released version at
 	       pack time (including in release.yaml), so an accidental breaking change fails the pack. Bump


### PR DESCRIPTION
**Release 0.7.2 — non-protected portion** (full CI, normal merge). PATCH: docs + CI only, **no public API or runtime change vs 0.7.1**.

### Included
- **#174** — runnable `<example>` blocks across the public API XML docs (`Die`, `Dice`, `IDie`/`IDice`, `AverageRoundedUp`/`AverageRoundedDown`); every snippet compile-verified against the library.
- **SECURITY.md** — new "Verifying a release" section (`gh attestation verify` + CycloneDX SBOM).
- **Version** `0.7.1 → 0.7.2`; **CHANGELOG** `[0.7.2]` entry.
- `PackageValidationBaselineVersion` stays **0.7.1** (validates the 0.7.2 API against the last published package; bumped to 0.7.2 post-release).

### Split
The release-workflow changes (`release.yaml` SLSA step + `sourcelink.yaml`) are in the companion protected-file PR so only that minimal change needs the admin bypass — this PR runs full CI. **Merge this one first.**

### Verified
`dotnet pack -c Release` succeeds; PackageValidation against 0.7.1 reports no API break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)