### PR TITLE
ci: v0.7.2 release-workflow changes (protected files)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -673,7 +673,8 @@ jobs:
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     permissions:
-      id-token: write   # required for OIDC token issuance to nuget.org (Trusted Publishing)
+      id-token: write       # required for OIDC token issuance to nuget.org (Trusted Publishing) AND for SLSA provenance signing
+      attestations: write   # required to record the SLSA build-provenance attestation on GitHub (#171)
       contents: read
     steps:
       - name: Setup .NET
@@ -693,6 +694,18 @@ jobs:
         with:
           name: nuget-packages
           path: ./packages
+
+      # SLSA build provenance (#171): generate a signed attestation binding each packed
+      # .nupkg (by SHA-256 digest) to the exact repo, commit and workflow run that produced
+      # it. Uses the workflow's OIDC identity — no signing key to manage (same keyless trust
+      # model as NuGet Trusted Publishing below). Attest BEFORE pushing so the provenance
+      # covers the exact bytes we publish; consumers verify with `gh attestation verify`.
+      # Package *signing* (an author signature) is intentionally out of scope — it needs a
+      # code-signing certificate.
+      - name: Attest build provenance for packages
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: './packages/*.nupkg'
 
       - name: NuGet login (OIDC → temporary API key)
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1

--- a/.github/workflows/sourcelink.yaml
+++ b/.github/workflows/sourcelink.yaml
@@ -1,0 +1,101 @@
+name: SourceLink
+
+# End-to-end SourceLink verification (#176).
+#
+# Directory.Build.props enables Microsoft.SourceLink.GitHub + EmbedUntrackedSources
+# and the release packs .snupkg symbol packages. That embeds, into every PDB, a
+# map from each source document to its raw.githubusercontent.com URL at the build
+# commit. If a release mis-tags the commit or the SourceLink map is wrong, a
+# consumer's "step into library source" (F11) silently falls back to a decompiled
+# assembly — and nothing catches it today.
+#
+# `dotnet sourcelink test` closes that gap without needing a live debugger: for
+# every document referenced by the PDB it fetches the mapped GitHub URL and fails
+# unless the downloaded content's checksum matches the one embedded in the PDB.
+# That exercises the exact chain that step-into depends on — commit-SHA embedded
+# in the PDB + GitHub raw-URL resolution. Embedded (untracked) documents need no
+# URL and are verified in place. The PDB tested here is byte-identical to the one
+# shipped inside the .snupkg, so this covers the symbol-package path too.
+#
+# Runs on PRs so a SourceLink regression is caught before it can ship, using the
+# PR's pushed commit (whose raw URLs resolve on GitHub).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sourcelink-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sourcelink:
+    name: Verify SourceLink
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src projects
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping SourceLink verification."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      # Build each src project (not the whole solution — benchmarks/examples may
+      # target older TFMs only, so `-f net10.0` at the solution level would fail).
+      # ContinuousIntegrationBuild=true normalises source paths exactly as a
+      # release does, so the PDB embeds the same SourceLink map the shipped
+      # package carries.
+      - name: Build src projects (Release, net10.0)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          while IFS= read -r proj; do
+            echo "== build $proj =="
+            dotnet build "$proj" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+      - name: Install sourcelink tool
+        if: steps.detect.outputs.found == 'true'
+        run: dotnet tool install --global sourcelink
+
+      - name: Verify SourceLink resolves for every PDB
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          shopt -s globstar nullglob
+          pdbs=(src/**/bin/Release/net10.0/*.pdb)
+          if [ ${#pdbs[@]} -eq 0 ]; then
+            echo "::error::No PDBs found under src/**/bin/Release/net10.0 — SourceLink cannot be verified."
+            exit 1
+          fi
+          failed=0
+          for pdb in "${pdbs[@]}"; do
+            echo "== sourcelink test $pdb =="
+            if ! sourcelink test "$pdb"; then
+              echo "::error::SourceLink verification failed for $pdb — a debugger would fall back to decompiled source."
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ SourceLink resolves for all PDBs — step-into will fetch real source from GitHub."


### PR DESCRIPTION
**Release 0.7.2 — protected-file portion** (admin-bypass merge). Companion to the release/v0.7.2 PR.

### Included (workflow files only)
- **`release.yaml`** — SLSA build-provenance attestation of each published `.nupkg` (#171), keyless via the publish job's OIDC identity (pin corrected to the `v4.1.1` commit SHA per zizmor).
- **`sourcelink.yaml`** — new SourceLink resolution gate (#176).

### Why split
The protected-file guard blocks any PR touching `.github/workflows/*`, and an admin bypass waives **all** ruleset rules. Isolating just these two files here keeps full CI on the library/docs (the release/v0.7.2 PR) and limits the bypass to workflow YAML that already passed actionlint + zizmor on their original PRs (#248, #249).

### Merge order
Merge **after** release/v0.7.2, and **before** tagging `v0.7.2` — the release runs `release.yaml` from the tag's commit, so the SLSA step must be on `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)