### PR TITLE
release: bump PackageValidation baseline to 0.7.2 (post-release) [DO NOT MERGE until 0.7.2 published]

### DIFF
--- a/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
+++ b/src/Wolfgang.D20.Dice/Wolfgang.D20.Dice.csproj
@@ -11,7 +11,7 @@
 	       pack time (including in release.yaml), so an accidental breaking change fails the pack. Bump
 	       the baseline on each release. Waive an intentional break with an ApiCompatSuppressionFile. -->
 	  <EnablePackageValidation>true</EnablePackageValidation>
-	  <PackageValidationBaselineVersion>0.7.1</PackageValidationBaselineVersion>
+	  <PackageValidationBaselineVersion>0.7.2</PackageValidationBaselineVersion>
 	  <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	       do not need to recompile / add binding redirects on every minor/patch
 	       bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
**Draft / blocked.** Post-release housekeeping — advances `PackageValidationBaselineVersion` `0.7.1 → 0.7.2` so future builds diff their API surface against 0.7.2.

### ⚠️ Do not merge until v0.7.2 is live on NuGet
PackageValidation downloads the baseline package (`Wolfgang.D20.Dice 0.7.2`) from the feed at pack time. Until 0.7.2 is published, that download 404s and **CI (pack) is red**. Once 0.7.2 is on nuget.org, re-run checks — they'll go green — then mark ready and merge.

### Stacked on #250
Branched off `release/v0.7.2`, so while #250 is open this PR shows its changes too. After #250 merges to `main`, the diff here collapses to the single baseline line.

### Release checklist context
1. Merge #250 (full CI) → 2. Merge #251 (admin-bypass) → 3. Tag & publish `v0.7.2` → **4. this PR** → 5. delete `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)