### PR TITLE
docs(dice): fix WithModifier examples to derive from an existing pool (#239 review)

### DIFF
--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -121,8 +121,8 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
     /// </remarks>
     /// <example>
     /// <code>
-    /// var dice = new Dice(1, 20).WithModifier(5); // 1d20+5
-    /// int total = dice.Roll(); // a value in [6, 25]
+    /// var attack = new Dice(1, 20, 2);        // 1d20+2 — modifier set at construction
+    /// var blessed = attack.WithModifier(5);   // 1d20+5 — a new pool; 'attack' is unchanged
     /// </code>
     /// </example>
     public int Modifier { get; }
@@ -257,7 +257,8 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
     /// <returns>A new <see cref="Dice"/> whose <see cref="Modifier"/> is <paramref name="modifier"/>.</returns>
     /// <example>
     /// <code>
-    /// var buffed = new Dice(1, 20).WithModifier(5); // 1d20+5
+    /// var attack = new Dice(1, 20, 2);      // 1d20+2
+    /// var buffed = attack.WithModifier(5);  // 1d20+5 — derived from attack, which is unchanged
     /// </code>
     /// </example>
     public Dice WithModifier(int modifier)


### PR DESCRIPTION
Follow-up to the review comment on #253 — which merged into `vNext` **before** the fix commit landed, so the fix needs its own PR.

## Problem
Two XML-doc examples on `Dice` used the pointless construct-then-override pattern `new Dice(1, 20).WithModifier(5)` — if you're constructing fresh, you'd pass the modifier to the constructor (`new Dice(1, 20, 5)`).

## Fix
Both examples now set the modifier via the constructor and use `WithModifier` for its actual purpose — deriving a new pool with a different modifier from an existing instance (original unchanged):

- **`Modifier` property:**
  ```csharp
  var attack = new Dice(1, 20, 2);      // 1d20+2 — modifier set at construction
  var blessed = attack.WithModifier(5); // 1d20+5 — a new pool; 'attack' is unchanged
  ```
- **`WithModifier` method** (same anti-pattern, fixed for consistency):
  ```csharp
  var attack = new Dice(1, 20, 2);      // 1d20+2
  var buffed = attack.WithModifier(5);  // 1d20+5 — derived from attack, which is unchanged
  ```

Docs-only; build clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)