### PR TITLE
release: set 0.8.0 changelog date to 2026-07-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.8.0] - 2026-07-16
+## [0.8.0] - 2026-07-17
 
 `Dice` becomes an **immutable value type** (#239) — a breaking API change, shipped as a MINOR
 bump because the library is pre-1.0. See


### PR DESCRIPTION
One-line docs fix ahead of tagging **v0.8.0**. The `[0.8.0]` CHANGELOG heading was dated `2026-07-16` (when it was staged), but the release was deliberately held a day to avoid stacking with 0.7.2. Correct it to the actual publish date, **2026-07-17**.

Docs-only — merge this, then tag `v0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)