### PR TITLE
Add PublicAPI tracking files (closes #262)

### DIFF
--- a/src/Wolfgang.D20.Dice/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.D20.Dice/PublicAPI.Shipped.txt
@@ -1,0 +1,47 @@
+#nullable enable
+override Wolfgang.D20.Dice.Equals(object? obj) -> bool
+override Wolfgang.D20.Dice.GetHashCode() -> int
+override Wolfgang.D20.Dice.ToString() -> string!
+override Wolfgang.D20.Die.Equals(object? obj) -> bool
+override Wolfgang.D20.Die.GetHashCode() -> int
+override Wolfgang.D20.Die.ToString() -> string!
+static Wolfgang.D20.AverageRollExtensions.AverageRoundedDown(this Wolfgang.D20.IDice! dice) -> int
+static Wolfgang.D20.AverageRollExtensions.AverageRoundedDown(this Wolfgang.D20.IDie! die) -> int
+static Wolfgang.D20.AverageRollExtensions.AverageRoundedUp(this Wolfgang.D20.IDice! dice) -> int
+static Wolfgang.D20.AverageRollExtensions.AverageRoundedUp(this Wolfgang.D20.IDie! die) -> int
+static Wolfgang.D20.Dice.TryParse(string? notation) -> Wolfgang.TryPattern.Result<Wolfgang.D20.Dice?>!
+Wolfgang.D20.AverageRollExtensions
+Wolfgang.D20.Dice
+Wolfgang.D20.Dice.Count.get -> int
+Wolfgang.D20.Dice.Dice(int dieCount = 1, int sideCount = 6, int modifier = 0) -> void
+Wolfgang.D20.Dice.Dice(System.Collections.Generic.IEnumerable<Wolfgang.D20.Die!>! dice, int modifier = 0) -> void
+Wolfgang.D20.Dice.DieCount.get -> int
+Wolfgang.D20.Dice.Equals(Wolfgang.D20.Dice? other) -> bool
+Wolfgang.D20.Dice.GetEnumerator() -> System.Collections.Generic.IEnumerator<Wolfgang.D20.Die!>!
+Wolfgang.D20.Dice.MaxValue.get -> int
+Wolfgang.D20.Dice.MinValue.get -> int
+Wolfgang.D20.Dice.Modifier.get -> int
+Wolfgang.D20.Dice.Roll() -> int
+Wolfgang.D20.Dice.WithDie(Wolfgang.D20.Die! die) -> Wolfgang.D20.Dice!
+Wolfgang.D20.Dice.WithModifier(int modifier) -> Wolfgang.D20.Dice!
+Wolfgang.D20.Dice.Without(Wolfgang.D20.Die! die) -> Wolfgang.D20.Dice!
+Wolfgang.D20.Die
+Wolfgang.D20.Die.Die(int sideCount = 6) -> void
+Wolfgang.D20.Die.Equals(Wolfgang.D20.Die? other) -> bool
+Wolfgang.D20.Die.MaxValue.get -> int
+Wolfgang.D20.Die.MinValue.get -> int
+Wolfgang.D20.Die.Roll() -> int
+Wolfgang.D20.Die.SideCount.get -> int
+Wolfgang.D20.IDice
+Wolfgang.D20.IDice.DieCount.get -> int
+Wolfgang.D20.IDice.MaxValue.get -> int
+Wolfgang.D20.IDice.MinValue.get -> int
+Wolfgang.D20.IDice.Modifier.get -> int
+Wolfgang.D20.IDice.Roll() -> int
+Wolfgang.D20.IDice.ToString() -> string!
+Wolfgang.D20.IDie
+Wolfgang.D20.IDie.MaxValue.get -> int
+Wolfgang.D20.IDie.MinValue.get -> int
+Wolfgang.D20.IDie.Roll() -> int
+Wolfgang.D20.IDie.SideCount.get -> int
+Wolfgang.D20.IDie.ToString() -> string!

--- a/src/Wolfgang.D20.Dice/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.D20.Dice/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

- Seeds `src/Wolfgang.D20.Dice/PublicAPI.Shipped.txt` with the v0.8.0 public API surface (Die, Dice, IDie, IDice, AverageRollExtensions).
- Adds empty `PublicAPI.Unshipped.txt` (header only) so future public API additions land there and get promoted at release time.

## Why

`Directory.Build.props` references `Microsoft.CodeAnalysis.PublicApiAnalyzers` and includes `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` as `AdditionalFiles` conditionally on `Exists`. Neither file existed for the single `src/` project, so:

- `RS0017` (the whole point — flag when a public API is removed) had no baseline and could not fire.
- `RS0016` (add-new-API without declaration) fired for every public declaration and produced ~195 open InspectCode alerts on `main` (161 `RS0016` + 34 `RS0037`).

Fleet convention (per Chris-Wolfgang/ETL-Abstractions#302, ETL-Csv, System.Mail-Extensions): `RS0016` stays disabled fleet-wide (hand-maintain); `RS0017` IS enforced. Since 0.8.0 is already released, the current API surface belongs in `Shipped.txt`; `Unshipped.txt` stays empty until a future addition.

## Impact

- Local `dotnet build src/Wolfgang.D20.Dice -c Release -p:TreatWarningsAsErrors=true`: 0 errors, no RS0016/RS0037 across all four TFMs (net462, netstandard2.0, net8.0, net10.0).
- Expected reduction: ~195 InspectCode alerts on next Code Scanning run.

## Test plan

- [x] Local Release build across all 4 TFMs with `TreatWarningsAsErrors=true`.
- [ ] CI (Stages 1/2/3) green on PR.
- [ ] After merge: verify Code Scanning open InspectCode alerts drop from 223 to ~28.

## Related

- Closes #262
- Part of #271 (code-scanning cleanup — InspectCode/Scorecard/zizmor)