### PR TITLE
Silence remaining InspectCode alerts (#271)

### DIFF
--- a/benchmarks/Wolfgang.D20.Dice.Benchmarks/DiceBenchmarks.cs
+++ b/benchmarks/Wolfgang.D20.Dice.Benchmarks/DiceBenchmarks.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Attributes;
+// ReSharper disable RedundantArgumentDefaultValue — explicit `Dice(1, 20)` / `Dice(1, 6)` names the benchmark scenario.
 
 namespace Wolfgang.D20.Benchmarks;
 

--- a/examples/Net4.8/Example1-Console/Program.cs
+++ b/examples/Net4.8/Example1-Console/Program.cs
@@ -9,13 +9,13 @@ namespace Example1_Console
         {
 
             Console.Write("Enter the number of sides: ");
-            var sideCount = int.Parse(Console.ReadLine(), System.Globalization.CultureInfo.InvariantCulture);
+            var sideCount = int.Parse(Console.ReadLine() ?? string.Empty, System.Globalization.CultureInfo.InvariantCulture);
 
             Console.Write("Enter the number of dice: ");
-            var dieCount = int.Parse(Console.ReadLine(), System.Globalization.CultureInfo.InvariantCulture);
+            var dieCount = int.Parse(Console.ReadLine() ?? string.Empty, System.Globalization.CultureInfo.InvariantCulture);
 
             Console.Write("Enter a modifier (default 0): ");
-            var modifier = int.Parse(Console.ReadLine(), System.Globalization.CultureInfo.InvariantCulture);
+            var modifier = int.Parse(Console.ReadLine() ?? string.Empty, System.Globalization.CultureInfo.InvariantCulture);
 
             var dice = new Dice(dieCount, sideCount, modifier);
 

--- a/src/Wolfgang.D20.Dice/Dice.cs
+++ b/src/Wolfgang.D20.Dice/Dice.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -42,6 +43,7 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
     /// int total = attack.Roll(); // a value in [5, 15]
     /// </code>
     /// </example>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple overloads with optional parameters", Justification = "This constructor was released in 0.8.0 alongside the (IEnumerable<Die>, int) overload; changing either signature is a SemVer breaking change.")]
     public Dice(int dieCount = 1, int sideCount = 6, int modifier = 0)
     {
         if (dieCount < 1)
@@ -78,6 +80,7 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
     /// var dice = new Dice(new[] { new Die(6), new Die(4) }, modifier: 1);
     /// </code>
     /// </example>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple overloads with optional parameters", Justification = "This constructor was released in 0.8.0 alongside the (int, int, int) overload; changing either signature is a SemVer breaking change.")]
     public Dice(IEnumerable<Die> dice, int modifier = 0)
     {
         if (dice is null)
@@ -465,6 +468,8 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
     /// }
     /// </code>
     /// </example>
+    [SuppressMessage("Major Code Smell", "S8969:Remove this null-forgiving operator", Justification = "`notation!` is required on net462/netstandard2.0 whose string.IsNullOrWhiteSpace lacks [NotNullWhen(false)]; the ! is redundant on modern TFMs only.")]
+    [SuppressMessage("Major Code Smell", "S3267:Loops should be simplified with 'LINQ' expressions", Justification = "The explicit foreach + StringBuilder loop is a zero-allocation hot path; LINQ .Where(...).ToArray() would allocate an IEnumerator plus intermediate char[].")]
     public static Result<Dice?> TryParse(string? notation)
     {
         if (string.IsNullOrWhiteSpace(notation))
@@ -478,8 +483,9 @@ public sealed class Dice : IDice, IReadOnlyCollection<Die>, IEquatable<Dice>
         // intermediate IEnumerator plus a char[] per call, whereas this appends straight
         // into a right-sized StringBuilder. notation! is required on target frameworks
         // whose string.IsNullOrWhiteSpace lacks [NotNullWhen] (net462/netstandard2.0).
-        // ReSharper disable once LoopCanBeConvertedToLinq
+        // ReSharper disable once RedundantSuppressNullableWarningExpression
         var compact = new StringBuilder(notation!.Length);
+        // ReSharper disable once LoopCanBeConvertedToLinq
         foreach (var character in notation)
         {
             if (!char.IsWhiteSpace(character))

--- a/tests/Wolfgang.D20.Dice.Tests/AllocationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/AllocationTests.cs
@@ -1,5 +1,7 @@
 #if NET6_0_OR_GREATER
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
+// ReSharper disable RedundantArgumentDefaultValue — explicit `Die(6)` documents the heterogeneous d6+d6+d4 pool under measurement.
 
 namespace Wolfgang.D20.Tests.Unit;
 

--- a/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/AverageRollExtensionsTests.cs
@@ -1,3 +1,4 @@
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 

--- a/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/DiceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 
@@ -133,6 +134,10 @@ public class DiceTests
     [Fact]
     public void Constructed_from_sequence_containing_null_throws_ArgumentException()
     {
+        // Explicit `Die?[]` is required because arrays are invariant: an inferred
+        // `new[] { new Die(6), null }` would bind to `Die[]` under nullable-enabled
+        // and can't legally hold a null element.
+        // ReSharper disable once RedundantExplicitArrayCreation
         var source = new Die?[] { new Die(6), null };
         Assert.Throws<ArgumentException>(() => new Dice(source!));
     }

--- a/tests/Wolfgang.D20.Dice.Tests/DieTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/DieTests.cs
@@ -1,3 +1,4 @@
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
 

--- a/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/GlobalizationTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
 
 namespace Wolfgang.D20.Tests.Unit;

--- a/tests/Wolfgang.D20.Dice.Tests/PropertyTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/PropertyTests.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 using CsCheck;
+// ReSharper disable once RedundantUsingDirective — required on TFMs where Verify.Xunit's global usings aren't in play (net10.0 only pulls Verify.Xunit)
 using Xunit;
 
 namespace Wolfgang.D20.Tests.Unit;

--- a/tests/Wolfgang.D20.Dice.Tests/SnapshotTests.cs
+++ b/tests/Wolfgang.D20.Dice.Tests/SnapshotTests.cs
@@ -1,7 +1,7 @@
 #if NET10_0_OR_GREATER
 using System.Text;
-using Xunit;
-using static VerifyXunit.Verifier;
+// Xunit and static VerifyXunit.Verifier are auto-injected by Verify.Xunit's global usings on net10.0, this file's only TFM.
+// ReSharper disable RedundantArgumentDefaultValue — explicit `sideCount: 6` / `dieCount: 1` labels each snapshot row with the dice configuration under test.
 
 namespace Wolfgang.D20.Tests.Unit;
 


### PR DESCRIPTION
## Summary

Addresses the 28 non-PublicAPI InspectCode alerts left after #272. **All suppressions are per-site (attribute, per-line, or per-file comment); no `.DotSettings` file is added.** Every suppression is documented with a why-not-fix justification.

## Where the code was WRONG — fixed

- **`examples/Net4.8/Example1-Console/Program.cs`** — 3 × `AssignNullToNotNullAttribute`. `int.Parse(Console.ReadLine(), …)` would throw an unhelpful `NullReferenceException` on Ctrl-Z / EOF. Null-coalesced to `string.Empty` so it throws `FormatException` naming the invalid input instead.
- **`tests/…/SnapshotTests.cs`** — 2 × `RedundantUsingDirective`. `using Xunit;` and `using static VerifyXunit.Verifier;` really were redundant here: this file is `#if NET10_0_OR_GREATER`-guarded, and on net10.0 `Verify.Xunit` auto-injects both as `global using`s. Removed the file-level usings; tests still pass.

## Where the WARNING was wrong — suppressed at the specific site

Each of these has a code comment already documenting why the current code is correct.

- **`src/Dice.cs`** — RS0026 on both `Dice` constructors. `[SuppressMessage]` per-ctor, justified by 0.8.0 SemVer lock-in (the two-optional-parameter overload set was released and cannot be reshaped without a breaking change).
- **`src/Dice.cs`** — S8969 + S3267 on `TryParse`. `[SuppressMessage]` on the method, justified by (a) the `notation!` guard being required on TFMs where `IsNullOrWhiteSpace` lacks `[NotNullWhen(false)]` (net462, netstandard2.0), and (b) the explicit `foreach + StringBuilder` loop being a zero-allocation hot path (LINQ would allocate an `IEnumerator` and intermediate `char[]`).
- **`src/Dice.cs`** — RedundantSuppressNullableWarningExpression: per-line `// ReSharper disable once` above the `notation!.Length` call.
- **`tests/…` (6 files)** — 6 × `RedundantUsingDirective` on `using Xunit;`. Per-line `// ReSharper disable once` above each. InspectCode analyzes the net10.0 build only (where `Verify.Xunit` auto-injects `global using Xunit;`), but building the test project on net8.0 or below fails without the file-level using (`FactAttribute` unresolved). Verified with `dotnet build -f net8.0`.
- **`tests/…/DiceTests.cs:136`** — `RedundantExplicitArrayCreation`. Per-line `// ReSharper disable once`. The explicit `Die?[]` is required because arrays are invariant: an inferred `new[] { new Die(6), null }` binds to `Die[]` under nullable-enabled and can't legally hold a null element.

## Where the WARNING was wrong — suppressed at file scope, matching the existing fleet pattern

The tests `DieTests.cs`, `DiceTests.cs`, and `AverageRollExtensionsTests.cs` already carry file-scoped `// ReSharper disable RedundantArgumentDefaultValue`. Extending the same file-scoped suppression to:

- **`tests/…/SnapshotTests.cs`** (5 alerts)
- **`tests/…/AllocationTests.cs`** (4 alerts)
- **`benchmarks/…/DiceBenchmarks.cs`** (2 alerts)

In each of these files the explicit `sideCount: 6` / `dieCount: 1` / `modifier: 2` values are load-bearing documentation — they label which dice configuration is under test / measurement. Removing them would leave bare `new Die()` / `new Dice()` calls that no longer document intent.

## Test plan

- [x] `dotnet build -c Release -p:TreatWarningsAsErrors=true` — 0 errors across net462 / netstandard2.0 / net8.0 / net10.0 for src, all TFMs for tests + benchmarks + examples.
- [x] `dotnet test tests/Wolfgang.D20.Dice.Tests -f net10.0 -c Release --no-build` — **185 / 185** passing (includes `SnapshotTests` which had `using`s removed).
- [ ] CI (Stages 1/2/3) green on the PR.
- [ ] After merge: verify Code Scanning open InspectCode alerts drop to ~0.

## Test-file changes surfaced for review

Per fleet convention (test-file edits need explicit review):

- 6 tests: 1-line per-file `// ReSharper disable once RedundantUsingDirective` comment.
- 3 files: 1-line per-file `// ReSharper disable RedundantArgumentDefaultValue` comment (matching pre-existing pattern in three sibling tests).
- 1 test: per-line ReSharper directive above the `Die?[]` array literal.
- SnapshotTests.cs: removed 2 usings that were truly redundant (verified via successful build + full test run).

No test assertions or behavior changed.

## Related

- Part of #271 (code-scanning cleanup)
- Stacks logically on #272 (PublicAPI files) but has no code dependency on it.