### PR TITLE
Fix zizmor template-injection in codeql.yaml (#271)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -166,14 +166,23 @@ jobs:
     - name: Complete Security Scan
       if: always()
       shell: pwsh
+      # Pass step outcomes / outputs via env rather than expanding `${{ … }}` directly into
+      # the script body — zizmor flags any `${{ steps.*.outputs.* }}` expansion inside a
+      # `run:` block as a potential template-injection vector, even for internal-only outputs.
+      # Reading through `$env:*` treats the values as opaque strings and closes the vector.
+      env:
+        CHECK_CSHARP_OUTCOME: ${{ steps.check-csharp.outcome }}
+        HAS_CSHARP: ${{ steps.check-csharp.outputs.has-csharp }}
+        BUILD_OUTCOME: ${{ steps.build.outcome }}
+        CODEQL_OUTCOME: ${{ steps.perform-codeql-analysis.outcome }}
       run: |
         Write-Host "=== CodeQL Security Scan Complete ===" -ForegroundColor Cyan
-        
+
         # Check the outcome of previous steps
-        $checkCsharpOutcome = "${{ steps.check-csharp.outcome }}"
-        $hasCsharp = "${{ steps.check-csharp.outputs.has-csharp }}"
-        $buildOutcome = "${{ steps.build.outcome }}"
-        $codeqlOutcome = "${{ steps.perform-codeql-analysis.outcome }}"
+        $checkCsharpOutcome = $env:CHECK_CSHARP_OUTCOME
+        $hasCsharp = $env:HAS_CSHARP
+        $buildOutcome = $env:BUILD_OUTCOME
+        $codeqlOutcome = $env:CODEQL_OUTCOME
         
         # Determine overall status
         $hasFailure = $false


### PR DESCRIPTION
## Summary

Fixes the last non-deferred zizmor alert on `main`: `zizmor/template-injection` at `codeql.yaml:174`.

The `Complete Security Scan` step expanded `\${{ steps.check-csharp.outputs.has-csharp }}` directly into the pwsh `run:` body. zizmor flags any `\${{ steps.*.outputs.* }}` inside a shell block as a potential template-injection vector — even for internal-only outputs whose values the workflow controls.

Fix: move all four expansions (`check-csharp.outcome`, `check-csharp.outputs.has-csharp`, `build.outcome`, `perform-codeql-analysis.outcome`) into an `env:` map and read them through `\$env:*`. The values are then treated as opaque strings and the injection vector is closed.

The step's behavior is unchanged; only the value-passing mechanism differs.

## Heads-up: expects the protected-files bypass

Touching `.github/workflows/codeql.yaml` trips the `Detect .NET Projects` guard (that's by design — a maintainer reviews any workflow-file change). Please review the diff and merge via admin bypass, or split further if you'd like. It's a single-file 14-insertion / 5-deletion change.

## Test plan

- [x] `yaml.safe_load` parses the modified file.
- [x] No behavioral change to the pwsh script — it still reads the same four variables and reaches the same branches.
- [ ] CI green on the PR (Detect .NET Projects will flag; other checks should pass).
- [ ] After merge: zizmor open count drops from 9 to 8, template-injection alert closed.

## Related

- Part of #271
- This is the sole surviving actionable item from the closed PR #274.